### PR TITLE
Add method for ACL validation

### DIFF
--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -322,6 +322,18 @@ func (c *Client) SetACL(ctx context.Context, acl ACL) error {
 	return c.performRequest(req, nil)
 }
 
+// ValidateACL validates the provided ACL via the API.
+func (c *Client) ValidateACL(ctx context.Context, acl ACL) error {
+	const uriFmt = "/api/v2/tailnet/%s/acl/validate"
+
+	req, err := c.buildRequest(ctx, http.MethodPost, fmt.Sprintf(uriFmt, c.tailnet), acl)
+	if err != nil {
+		return err
+	}
+
+	return c.performRequest(req, nil)
+}
+
 type DNSPreferences struct {
 	MagicDNS bool `json:"magicDNS"`
 }


### PR DESCRIPTION
This commit adds a `ValidateACL` method to the `Client` type that will be used to check the ACL is well formatted and the specified tests pass. It uses the JSON object method described in the API documentation.

This will be required for implementing additional validation as requested on the terraform provider:

https://github.com/tailscale/terraform-provider-tailscale/issues/158

Signed-off-by: David Bond <davidsbond93@gmail.com>