### PR TITLE
Run CI on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 on:
   push:
     branches:
-      - master
+      - main
   pull_request: {}
 
 jobs:


### PR DESCRIPTION
This commit modifies the actions workflow to trigger for the `main` branch. It was previously using `master` but has since been updated.

Signed-off-by: David Bond <davidsbond93@gmail.com>