### PR TITLE
Add method for listing keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # tailscale-client-go
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/davidsbond/tailscale-client-go.svg)](https://pkg.go.dev/github.com/davidsbond/tailscale-client-go)
-[![Go Report Card](https://goreportcard.com/badge/github.com/davidsbond/tailscale-client-go)](https://goreportcard.com/report/github.com/davidsbond/tailscale-client-go)
-![Github Actions](https://github.com/davidsbond/tailscale-client-go/actions/workflows/ci.yml/badge.svg?branch=master)
+[![Go Reference](https://pkg.go.dev/badge/github.com/tailscale/tailscale-client-go.svg)](https://pkg.go.dev/github.com/tailscale/tailscale-client-go)
+[![Go Report Card](https://goreportcard.com/badge/github.com/tailscale/tailscale-client-go)](https://goreportcard.com/report/github.com/tailscale/tailscale-client-go)
+![Github Actions](https://github.com/tailscale/tailscale-client-go/actions/workflows/ci.yml/badge.svg?branch=master)
 
 
 A client implementation for the [Tailscale](https://tailscale.com) HTTP API
@@ -17,7 +17,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/davidsbond/tailscale-client-go/tailscale"
+	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 func main() {

--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -550,6 +550,24 @@ func (c *Client) GetKey(ctx context.Context, id string) (Key, error) {
 	return key, c.performRequest(req, &key)
 }
 
+// Keys returns all keys within the tailnet. The only fields set for each key will be its identifier. The keys returned
+// are relative to the user that owns the API key used to authenticate the client.
+func (c *Client) Keys(ctx context.Context) ([]Key, error) {
+	const uriFmt = "/api/v2/tailnet/%s/keys"
+
+	req, err := c.buildRequest(ctx, http.MethodGet, fmt.Sprintf(uriFmt, c.tailnet), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := make(map[string][]Key)
+	if err = c.performRequest(req, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp["keys"], nil
+}
+
 // DeleteKey removes an authentication key from the tailnet.
 func (c *Client) DeleteKey(ctx context.Context, id string) error {
 	const uriFmt = "/api/v2/tailnet/%s/keys/%s"

--- a/tailscale/client_test.go
+++ b/tailscale/client_test.go
@@ -669,6 +669,28 @@ func TestClient_GetKey(t *testing.T) {
 	assert.Equal(t, "/api/v2/tailnet/example.com/keys/"+expected.ID, server.Path)
 }
 
+func TestClient_Keys(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	expected := []tailscale.Key{
+		{ID: "key-a"},
+		{ID: "key-b"},
+	}
+
+	server.ResponseBody = map[string][]tailscale.Key{
+		"keys": expected,
+	}
+
+	actual, err := client.Keys(context.Background())
+	assert.NoError(t, err)
+	assert.EqualValues(t, expected, actual)
+	assert.Equal(t, http.MethodGet, server.Method)
+	assert.Equal(t, "/api/v2/tailnet/example.com/keys", server.Path)
+}
+
 func TestClient_DeleteKey(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #28

This commit adds the `Client.Keys` method that will return a list of all active keys within the tailnet for the user who owns the API key.

Signed-off-by: David Bond <davidsbond93@gmail.com>