### PR TITLE
add expiry to key capabilities

### DIFF
--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -506,6 +506,7 @@ type (
 				Ephemeral     bool     `json:"ephemeral"`
 				Tags          []string `json:"tags"`
 				Preauthorized bool     `json:"preauthorized"`
+				Expiry        int      `json:"expirySeconds"`
 			} `json:"create"`
 		} `json:"devices"`
 	}

--- a/tailscale/client_test.go
+++ b/tailscale/client_test.go
@@ -623,6 +623,7 @@ func TestClient_CreateKey(t *testing.T) {
 	capabilities.Devices.Create.Reusable = true
 	capabilities.Devices.Create.Preauthorized = true
 	capabilities.Devices.Create.Tags = []string{"test:test"}
+	capabilities.Devices.Create.Expiry = 3600
 
 	expected := tailscale.Key{
 		ID:           "test",


### PR DESCRIPTION
Need key expiry in the terraform provider, and I saw it was not yet added to the client pkg, but is available in the API. 
Will open separate PR for terraform provider, if this is approved.
Thanks!