### PR TITLE
Allow specifying ETag value while setting ACLs

### DIFF
--- a/tailscale/tailscale_test.go
+++ b/tailscale/tailscale_test.go
@@ -20,6 +20,7 @@ type TestServer struct {
 	Method string
 	Path   string
 	Body   *bytes.Buffer
+	Header http.Header
 
 	ResponseCode int
 	ResponseBody interface{}
@@ -61,6 +62,7 @@ func NewTestHarness(t *testing.T) (*tailscale.Client, *TestServer) {
 func (t *TestServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	t.Method = r.Method
 	t.Path = r.URL.Path
+	t.Header = r.Header
 
 	t.Body = bytes.NewBuffer([]byte{})
 	_, err := io.Copy(t.Body, r.Body)


### PR DESCRIPTION
This adds a `WithETag` option that allows specifying an ETag value while writing ACL contents.

Also, a few missing ACL file fields have been added based on https://tailscale.com/kb/1018/acls/

Updates tailscale/terraform-provider-tailscale#182

Signed-off-by: Anton Tolchanov <anton@tailscale.com>