### PR TITLE
Fix incorrect case of tagOwners and autoApprovers

### DIFF
--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -292,10 +292,10 @@ type (
 	// ACL contains the schema for a tailnet policy file. More details: https://tailscale.com/kb/1018/acls/
 	ACL struct {
 		ACLs                []ACLEntry          `json:"acls,omitempty" hujson:"ACLs,omitempty"`
-		AutoApprovers       *ACLAutoApprovers   `json:"autoapprovers,omitempty" hujson:"AutoApprovers,omitempty"`
+		AutoApprovers       *ACLAutoApprovers   `json:"autoApprovers,omitempty" hujson:"AutoApprovers,omitempty"`
 		Groups              map[string][]string `json:"groups,omitempty" hujson:"Groups,omitempty"`
 		Hosts               map[string]string   `json:"hosts,omitempty" hujson:"Hosts,omitempty"`
-		TagOwners           map[string][]string `json:"tagowners,omitempty" hujson:"TagOwners,omitempty"`
+		TagOwners           map[string][]string `json:"tagOwners,omitempty" hujson:"TagOwners,omitempty"`
 		DERPMap             *ACLDERPMap         `json:"derpMap,omitempty" hujson:"DerpMap,omitempty"`
 		Tests               []ACLTest           `json:"tests,omitempty" hujson:"Tests,omitempty"`
 		SSH                 []ACLSSH            `json:"ssh,omitempty" hujson:"SSH,omitempty"`


### PR DESCRIPTION
tagOwners and autoApprovers are incorrectly serializing all lowercase, which is causing an inconsistency on the terraform provider: the terraform plan always show a diff between what is previously deployed (camelcase 'tagOwners' and 'autoApprovers') and the new plan (all lowercase 'tagowners' and 'autoapprovers'), regardless of whether those attributes were changed or not.