### PR TITLE
Add Description to CreateKeyRequest and update tests

### DIFF
--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -614,8 +614,8 @@ func WithKeyExpiry(e time.Duration) CreateKeyOption {
 	}
 }
 
-// WithDescription sets a description string for the key.
-func WithDescription(e string) CreateKeyOption {
+// WithKeyDescription sets a description string for the key.
+func WithKeyDescription(e string) CreateKeyOption {
 	return func(c *CreateKeyRequest) error {
 		c.Description = e
 		return nil

--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -589,6 +589,7 @@ type (
 	// The CreateKeyRequest type describes the definition of an authentication key to create.
 	CreateKeyRequest struct {
 		Capabilities  KeyCapabilities `json:"capabilities"`
+		Description   string          `json:"description"`
 		ExpirySeconds int64           `json:"expirySeconds"`
 	}
 
@@ -609,6 +610,14 @@ type (
 func WithKeyExpiry(e time.Duration) CreateKeyOption {
 	return func(c *CreateKeyRequest) error {
 		c.ExpirySeconds = int64(e.Seconds())
+		return nil
+	}
+}
+
+// WithDescription sets a description string for the key.
+func WithDescription(e string) CreateKeyOption {
+	return func(c *CreateKeyRequest) error {
+		c.Description = e
 		return nil
 	}
 }

--- a/tailscale/client_test.go
+++ b/tailscale/client_test.go
@@ -706,6 +706,41 @@ func TestClient_CreateKeyWithExpirySeconds(t *testing.T) {
 	assert.EqualValues(t, 1440, actualReq.ExpirySeconds)
 }
 
+func TestClient_CreateKeyWithDescription(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	capabilities := tailscale.KeyCapabilities{}
+	capabilities.Devices.Create.Ephemeral = true
+	capabilities.Devices.Create.Reusable = true
+	capabilities.Devices.Create.Preauthorized = true
+	capabilities.Devices.Create.Tags = []string{"test:test"}
+
+	expected := tailscale.Key{
+		ID:           "test",
+		Key:          "thisisatestkey",
+		Created:      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+		Expires:      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+		Capabilities: capabilities,
+	}
+
+	server.ResponseBody = expected
+
+	actual, err := client.CreateKey(context.Background(), capabilities, tailscale.WithKeyDescription("testkeydescription"))
+	assert.NoError(t, err)
+	assert.EqualValues(t, expected, actual)
+	assert.Equal(t, http.MethodPost, server.Method)
+	assert.Equal(t, "/api/v2/tailnet/example.com/keys", server.Path)
+
+	var actualReq tailscale.CreateKeyRequest
+	assert.NoError(t, json.Unmarshal(server.Body.Bytes(), &actualReq))
+	assert.EqualValues(t, capabilities, actualReq.Capabilities)
+	assert.EqualValues(t, 0, actualReq.ExpirySeconds)
+	assert.EqualValues(t, "testkeydescription", actualReq.Description)
+}
+
 func TestClient_GetKey(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Adds support for creating a key with a description string. Also updated tests. Reworked from how `WithKeyExpiry` is implemented.