### PR TITLE
Add `Description` property to `Key`

### DIFF
--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -590,6 +590,7 @@ type (
 	CreateKeyRequest struct {
 		Capabilities  KeyCapabilities `json:"capabilities"`
 		ExpirySeconds int64           `json:"expirySeconds"`
+		Description   string          `json:"description"`
 	}
 
 	// The CreateKeyOption type is a function that is used to modify a CreateKeyRequest.
@@ -599,6 +600,7 @@ type (
 	Key struct {
 		ID           string          `json:"id"`
 		Key          string          `json:"key"`
+		Description  string          `json:"description"`
 		Created      time.Time       `json:"created"`
 		Expires      time.Time       `json:"expires"`
 		Capabilities KeyCapabilities `json:"capabilities"`
@@ -609,6 +611,14 @@ type (
 func WithKeyExpiry(e time.Duration) CreateKeyOption {
 	return func(c *CreateKeyRequest) error {
 		c.ExpirySeconds = int64(e.Seconds())
+		return nil
+	}
+}
+
+// WithKeyDescription sets the description for the key.
+func WithKeyDescription(desc string) CreateKeyOption {
+	return func(c *CreateKeyRequest) error {
+		c.Description = desc
 		return nil
 	}
 }

--- a/tailscale/client_test.go
+++ b/tailscale/client_test.go
@@ -656,6 +656,7 @@ func TestClient_CreateKey(t *testing.T) {
 		Created:      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 		Expires:      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 		Capabilities: capabilities,
+		Description:  "",
 	}
 
 	server.ResponseBody = expected
@@ -670,6 +671,7 @@ func TestClient_CreateKey(t *testing.T) {
 	assert.NoError(t, json.Unmarshal(server.Body.Bytes(), &actualReq))
 	assert.EqualValues(t, capabilities, actualReq.Capabilities)
 	assert.EqualValues(t, 0, actualReq.ExpirySeconds)
+	assert.EqualValues(t, "", actualReq.Description)
 }
 
 func TestClient_CreateKeyWithExpirySeconds(t *testing.T) {
@@ -690,6 +692,7 @@ func TestClient_CreateKeyWithExpirySeconds(t *testing.T) {
 		Created:      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 		Expires:      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 		Capabilities: capabilities,
+		Description:  "",
 	}
 
 	server.ResponseBody = expected
@@ -704,6 +707,43 @@ func TestClient_CreateKeyWithExpirySeconds(t *testing.T) {
 	assert.NoError(t, json.Unmarshal(server.Body.Bytes(), &actualReq))
 	assert.EqualValues(t, capabilities, actualReq.Capabilities)
 	assert.EqualValues(t, 1440, actualReq.ExpirySeconds)
+	assert.EqualValues(t, "", actualReq.Description)
+}
+
+func TestClient_CreateKeyWithDescription(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	capabilities := tailscale.KeyCapabilities{}
+	capabilities.Devices.Create.Ephemeral = true
+	capabilities.Devices.Create.Reusable = true
+	capabilities.Devices.Create.Preauthorized = true
+	capabilities.Devices.Create.Tags = []string{"test:test"}
+
+	expected := tailscale.Key{
+		ID:           "test",
+		Key:          "thisisatestkey",
+		Created:      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+		Expires:      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+		Capabilities: capabilities,
+		Description:  "key description",
+	}
+
+	server.ResponseBody = expected
+
+	actual, err := client.CreateKey(context.Background(), capabilities, tailscale.WithKeyDescription("key description"))
+	assert.NoError(t, err)
+	assert.EqualValues(t, expected, actual)
+	assert.Equal(t, http.MethodPost, server.Method)
+	assert.Equal(t, "/api/v2/tailnet/example.com/keys", server.Path)
+
+	var actualReq tailscale.CreateKeyRequest
+	assert.NoError(t, json.Unmarshal(server.Body.Bytes(), &actualReq))
+	assert.EqualValues(t, capabilities, actualReq.Capabilities)
+	assert.EqualValues(t, 0, actualReq.ExpirySeconds)
+	assert.EqualValues(t, "key description", actualReq.Description)
 }
 
 func TestClient_GetKey(t *testing.T) {
@@ -723,6 +763,7 @@ func TestClient_GetKey(t *testing.T) {
 		Created:      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 		Expires:      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 		Capabilities: capabilities,
+		Description:  "",
 	}
 
 	server.ResponseBody = expected


### PR DESCRIPTION
The `Key` type is missing the `Description` property, this PR adds it in.