### PR TITLE
tailscale: add recently introduced fields

### DIFF
--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -559,10 +559,15 @@ func (c *Client) Devices(ctx context.Context) ([]Device, error) {
 
 // AuthorizeDevice marks the specified device identifier as authorized to join the tailnet.
 func (c *Client) AuthorizeDevice(ctx context.Context, deviceID string) error {
+	return c.SetDeviceAuthorized(ctx, deviceID, true)
+}
+
+// SetDeviceAuthorized marks the specified device as authorized or not.
+func (c *Client) SetDeviceAuthorized(ctx context.Context, deviceID string, authorized bool) error {
 	const uriFmt = "/api/v2/device/%s/authorized"
 
 	req, err := c.buildRequest(ctx, http.MethodPost, fmt.Sprintf(uriFmt, deviceID), nil, map[string]bool{
-		"authorized": true,
+		"authorized": authorized,
 	})
 	if err != nil {
 		return err

--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -286,6 +286,10 @@ type (
 		DisableIPv4         bool                `json:"disableIPv4,omitempty" hujson:"DisableIPv4,omitempty"`
 		OneCGNATRoute       string              `json:"oneCGNATRoute,omitempty" hujson:"OneCGNATRoute,omitempty"`
 		RandomizeClientPort bool                `json:"randomizeClientPort,omitempty" hujson:"RandomizeClientPort,omitempty"`
+
+		// As of Aug 2023 these fields are experimental and subject to change.
+		Postures             map[string][]string `json:"postures,omitempty" hujson:"Postures,omitempty"`
+		DefaultSourcePosture []string            `json:"defaultSrcPosture,omitempty" hujson:"DefaultSrcPosture,omitempty"`
 	}
 
 	ACLAutoApprovers struct {
@@ -300,6 +304,9 @@ type (
 		Source      []string `json:"src,omitempty" hujson:"Src,omitempty"`
 		Destination []string `json:"dst,omitempty" hujson:"Dst,omitempty"`
 		Protocol    string   `json:"proto,omitempty" hujson:"Proto,omitempty"`
+
+		// Experimental.
+		SourcePosture []string `json:"srcPosture,omitempty" hujson:"SrcPosture,omitempty"`
 	}
 
 	ACLTest struct {
@@ -338,11 +345,13 @@ type (
 	}
 
 	ACLSSH struct {
-		Action      string   `json:"action,omitempty" hujson:"Action,omitempty"`
-		Users       []string `json:"users,omitempty" hujson:"Users,omitempty"`
-		Source      []string `json:"src,omitempty" hujson:"Src,omitempty"`
-		Destination []string `json:"dst,omitempty" hujson:"Dst,omitempty"`
-		CheckPeriod Duration `json:"checkPeriod,omitempty" hujson:"CheckPeriod,omitempty"`
+		Action          string   `json:"action,omitempty" hujson:"Action,omitempty"`
+		Users           []string `json:"users,omitempty" hujson:"Users,omitempty"`
+		Source          []string `json:"src,omitempty" hujson:"Src,omitempty"`
+		Destination     []string `json:"dst,omitempty" hujson:"Dst,omitempty"`
+		CheckPeriod     Duration `json:"checkPeriod,omitempty" hujson:"CheckPeriod,omitempty"`
+		Recorder        []string `json:"recorder,omitempty" hujson:"Recorder,omitempty"`
+		EnforceRecorder bool     `json:"enforceRecorder,omitempty" hujson:"EnforceRecorder,omitempty"`
 	}
 
 	NodeAttrGrant struct {

--- a/tailscale/client_test.go
+++ b/tailscale/client_test.go
@@ -638,6 +638,25 @@ func TestClient_AuthorizeDevice(t *testing.T) {
 	assert.EqualValues(t, true, body["authorized"])
 }
 
+func TestClient_SetDeviceAuthorized(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	const deviceID = "test"
+
+	for _, value := range []bool{true, false} {
+		assert.NoError(t, client.SetDeviceAuthorized(context.Background(), deviceID, value))
+		assert.Equal(t, http.MethodPost, server.Method)
+		assert.Equal(t, "/api/v2/device/test/authorized", server.Path)
+
+		body := make(map[string]bool)
+		assert.NoError(t, json.Unmarshal(server.Body.Bytes(), &body))
+		assert.EqualValues(t, value, body["authorized"])
+	}
+}
+
 func TestClient_CreateKey(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
- Add support for the value of `false` in the `/authorized` endpoint.
- Update the ACL schema with some recently introduced fields.