### PR TITLE
tailscale: support logstream configuration endpoints

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -42,6 +42,7 @@ type (
 		devices    *DevicesResource
 		dns        *DNSResource
 		keys       *KeysResource
+		logging    *LoggingResource
 		policyFile *PolicyFileResource
 		webhooks   *WebhooksResource
 	}
@@ -99,6 +100,7 @@ func (c *Client) init() {
 		c.devices = &DevicesResource{c}
 		c.dns = &DNSResource{c}
 		c.keys = &KeysResource{c}
+		c.logging = &LoggingResource{c}
 		c.policyFile = &PolicyFileResource{c}
 		c.webhooks = &WebhooksResource{c}
 	})
@@ -136,6 +138,11 @@ func (c *Client) DNS() *DNSResource {
 func (c *Client) Keys() *KeysResource {
 	c.init()
 	return c.keys
+}
+
+func (c *Client) Logging() *LoggingResource {
+	c.init()
+	return c.logging
 }
 
 func (c *Client) PolicyFile() *PolicyFileResource {

--- a/v2/logging.go
+++ b/v2/logging.go
@@ -1,0 +1,79 @@
+package tsclient
+
+import (
+	"context"
+	"net/http"
+)
+
+type LoggingResource struct {
+	*Client
+}
+
+const (
+	LogstreamSplunkEndpoint  LogstreamEndpointType = "splunk"
+	LogstreamElasticEndpoint LogstreamEndpointType = "elastic"
+	LogstreamPantherEndpoint LogstreamEndpointType = "panther"
+	LogstreamCriblEndpoint   LogstreamEndpointType = "cribl"
+	LogstreamDatadogEndpoint LogstreamEndpointType = "datadog"
+	LogstreamAxiomEndpoint   LogstreamEndpointType = "axiom"
+)
+
+const (
+	LogTypeConfig  LogType = "configuration"
+	LogTypeNetwork LogType = "network"
+)
+
+type (
+	// LogstreamConfiguration type defines a log stream entity in tailscale.
+	LogstreamConfiguration struct {
+		LogType         LogType               `json:"logType,omitempty"`
+		DestinationType LogstreamEndpointType `json:"destinationType,omitempty"`
+		URL             string                `json:"url,omitempty"`
+		User            string                `json:"user,omitempty"`
+	}
+
+	// SetLogstreamConfigurationRequest type defines a request for setting a LogstreamConfiguration.
+	SetLogstreamConfigurationRequest struct {
+		DestinationType LogstreamEndpointType `json:"destinationType,omitempty"`
+		URL             string                `json:"url,omitempty"`
+		User            string                `json:"user,omitempty"`
+		Token           string                `json:"token,omitempty"`
+	}
+
+	// LogstreamEndpointType describes the type of the endpoint.
+	LogstreamEndpointType string
+
+	// LogType describes the type of logging.
+	LogType string
+)
+
+// LogstreamConfiguration retrieves a specific LogstreamConfiguration configuration for a tailnet with the given LogType.
+func (lr *LoggingResource) LogstreamConfiguration(ctx context.Context, logType LogType) (*LogstreamConfiguration, error) {
+	req, err := lr.buildRequest(ctx, http.MethodGet, lr.buildTailnetURL("logging", logType, "stream"))
+	if err != nil {
+		return nil, err
+	}
+
+	var logStream LogstreamConfiguration
+	return &logStream, lr.do(req, &logStream)
+}
+
+// SetLogstreamConfiguration sets the configuration for a LogstreamConfiguration for a tailnet with the given LogType.
+func (lr *LoggingResource) SetLogstreamConfiguration(ctx context.Context, logType LogType, request SetLogstreamConfigurationRequest) error {
+	req, err := lr.buildRequest(ctx, http.MethodPut, lr.buildTailnetURL("logging", logType, "stream"), requestBody(request))
+	if err != nil {
+		return err
+	}
+
+	return lr.do(req, nil)
+}
+
+// DeleteLogstreamConfiguration deletes a LogstreamConfiguration configuration in a tailnet with the given LogType.
+func (lr *LoggingResource) DeleteLogstreamConfiguration(ctx context.Context, logType LogType) error {
+	req, err := lr.buildRequest(ctx, http.MethodDelete, lr.buildTailnetURL("logging", logType, "stream"))
+	if err != nil {
+		return err
+	}
+
+	return lr.do(req, nil)
+}

--- a/v2/logging_test.go
+++ b/v2/logging_test.go
@@ -1,0 +1,63 @@
+package tsclient_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	tsclient "github.com/tailscale/tailscale-client-go/v2"
+)
+
+func TestClient_LogstreamConfiguration(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	expectedLogstream := &tsclient.LogstreamConfiguration{}
+	server.ResponseBody = expectedLogstream
+
+	actualWebhook, err := client.Logging().LogstreamConfiguration(context.Background(), tsclient.LogTypeConfig)
+	assert.NoError(t, err)
+	assert.Equal(t, http.MethodGet, server.Method)
+	assert.Equal(t, "/api/v2/tailnet/example.com/logging/configuration/stream", server.Path)
+	assert.Equal(t, expectedLogstream, actualWebhook)
+}
+
+func TestClient_SetLogstreamConfiguration(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	logstreamRequest := tsclient.SetLogstreamConfigurationRequest{
+		DestinationType: tsclient.LogstreamCriblEndpoint,
+		URL:             "http://example.com",
+		User:            "my-user",
+		Token:           "my-token",
+	}
+	server.ResponseBody = nil
+
+	err := client.Logging().SetLogstreamConfiguration(context.Background(), tsclient.LogTypeNetwork, logstreamRequest)
+	assert.NoError(t, err)
+	assert.Equal(t, http.MethodPut, server.Method)
+	assert.Equal(t, "/api/v2/tailnet/example.com/logging/network/stream", server.Path)
+	var receivedRequest tsclient.SetLogstreamConfigurationRequest
+	err = json.Unmarshal(server.Body.Bytes(), &receivedRequest)
+	assert.NoError(t, err)
+	assert.EqualValues(t, logstreamRequest, receivedRequest)
+}
+
+func TestClient_DeleteLogstream(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	err := client.Logging().DeleteLogstreamConfiguration(context.Background(), tsclient.LogTypeConfig)
+	assert.NoError(t, err)
+	assert.Equal(t, http.MethodDelete, server.Method)
+	assert.Equal(t, "/api/v2/tailnet/example.com/logging/configuration/stream", server.Path)
+}


### PR DESCRIPTION
Support logstream configuration endpoints in the client.

Updates https://github.com/tailscale/corp/issues/21623