### PR TITLE
v2: rename package from tailscale -> tsclient

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -1,8 +1,8 @@
-// Package tailscale contains a basic implementation of a client for the Tailscale HTTP api. Documentation is here:
+// Package tsclient contains a basic implementation of a client for the Tailscale HTTP api. Documentation is here:
 // https://github.com/tailscale/tailscale/blob/main/api.md
 //
 // WARNING - this v2 implementation is under active development, use at your own risk.
-package tailscale
+package tsclient
 
 import (
 	"bytes"

--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -1,4 +1,4 @@
-package tailscale
+package tsclient
 
 import (
 	_ "embed"

--- a/v2/contacts.go
+++ b/v2/contacts.go
@@ -1,4 +1,4 @@
-package tailscale
+package tsclient
 
 import (
 	"context"

--- a/v2/contacts_test.go
+++ b/v2/contacts_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tsclient_test
 
 import (
 	"context"
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tailscale/tailscale-client-go/v2"
+	tsclient "github.com/tailscale/tailscale-client-go/v2"
 )
 
 func TestClient_Contacts(t *testing.T) {
@@ -16,17 +16,17 @@ func TestClient_Contacts(t *testing.T) {
 	client, server := NewTestHarness(t)
 	server.ResponseCode = http.StatusOK
 
-	expectedContacts := &tailscale.Contacts{
-		Account: tailscale.Contact{
+	expectedContacts := &tsclient.Contacts{
+		Account: tsclient.Contact{
 			Email:             "test@example.com",
 			FallbackEmail:     "test2@example.com",
 			NeedsVerification: false,
 		},
-		Support: tailscale.Contact{
+		Support: tsclient.Contact{
 			Email:             "test3@example.com",
 			NeedsVerification: false,
 		},
-		Security: tailscale.Contact{
+		Security: tsclient.Contact{
 			Email:             "test4@example.com",
 			FallbackEmail:     "test5@example.com",
 			NeedsVerification: true,
@@ -49,14 +49,14 @@ func TestClient_UpdateContact(t *testing.T) {
 	server.ResponseBody = nil
 
 	email := "new@example.com"
-	updateRequest := tailscale.UpdateContactRequest{
+	updateRequest := tsclient.UpdateContactRequest{
 		Email: &email,
 	}
-	err := client.Contacts().Update(context.Background(), tailscale.ContactAccount, updateRequest)
+	err := client.Contacts().Update(context.Background(), tsclient.ContactAccount, updateRequest)
 	assert.NoError(t, err)
 	assert.Equal(t, http.MethodPatch, server.Method)
 	assert.Equal(t, "/api/v2/tailnet/example.com/contacts/account", server.Path)
-	var receivedRequest tailscale.UpdateContactRequest
+	var receivedRequest tsclient.UpdateContactRequest
 	err = json.Unmarshal(server.Body.Bytes(), &receivedRequest)
 	assert.NoError(t, err)
 	assert.EqualValues(t, updateRequest, receivedRequest)

--- a/v2/devices.go
+++ b/v2/devices.go
@@ -1,4 +1,4 @@
-package tailscale
+package tsclient
 
 import (
 	"context"
@@ -143,7 +143,7 @@ func (dr *DevicesResource) SetKey(ctx context.Context, deviceID string, key Devi
 }
 
 // SetDeviceIPv4Address sets the Tailscale IPv4 address of the device.
-func (dr *DevicesResource) SetDeviceIPv4Address(ctx context.Context, deviceID string, ipv4Address string) error {
+func (dr *DevicesResource) SetIPv4Address(ctx context.Context, deviceID string, ipv4Address string) error {
 	req, err := dr.buildRequest(ctx, http.MethodPost, dr.buildURL("device", deviceID, "ip"), requestBody(map[string]string{
 		"ipv4": ipv4Address,
 	}))

--- a/v2/devices_test.go
+++ b/v2/devices_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tsclient_test
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tailscale/tailscale-client-go/v2"
+	tsclient "github.com/tailscale/tailscale-client-go/v2"
 )
 
 var (
@@ -38,7 +38,7 @@ func TestClient_SetDeviceSubnetRoutes(t *testing.T) {
 func TestClient_Devices_Get(t *testing.T) {
 	t.Parallel()
 
-	expectedDevice := &tailscale.Device{
+	expectedDevice := &tsclient.Device{
 		Addresses:         []string{"127.0.0.1"},
 		Name:              "test",
 		ID:                "testid",
@@ -50,11 +50,11 @@ func TestClient_Devices_Get(t *testing.T) {
 		},
 		BlocksIncomingConnections: false,
 		ClientVersion:             "1.22.1",
-		Created:                   tailscale.Time{time.Date(2022, 2, 10, 11, 50, 23, 0, time.UTC)},
-		Expires:                   tailscale.Time{time.Date(2022, 8, 9, 11, 50, 23, 0, time.UTC)},
+		Created:                   tsclient.Time{time.Date(2022, 2, 10, 11, 50, 23, 0, time.UTC)},
+		Expires:                   tsclient.Time{time.Date(2022, 8, 9, 11, 50, 23, 0, time.UTC)},
 		Hostname:                  "test",
 		IsExternal:                false,
-		LastSeen:                  tailscale.Time{time.Date(2022, 3, 9, 20, 3, 42, 0, time.UTC)},
+		LastSeen:                  tsclient.Time{time.Date(2022, 3, 9, 20, 3, 42, 0, time.UTC)},
 		MachineKey:                "mkey:test",
 		NodeKey:                   "nodekey:test",
 		OS:                        "windows",
@@ -75,7 +75,7 @@ func TestClient_Devices_Get(t *testing.T) {
 func TestClient_Devices_List(t *testing.T) {
 	t.Parallel()
 
-	expectedDevices := map[string][]tailscale.Device{
+	expectedDevices := map[string][]tsclient.Device{
 		"devices": {
 			{
 				Addresses:         []string{"127.0.0.1"},
@@ -89,11 +89,11 @@ func TestClient_Devices_List(t *testing.T) {
 				},
 				BlocksIncomingConnections: false,
 				ClientVersion:             "1.22.1",
-				Created:                   tailscale.Time{time.Date(2022, 2, 10, 11, 50, 23, 0, time.UTC)},
-				Expires:                   tailscale.Time{time.Date(2022, 8, 9, 11, 50, 23, 0, time.UTC)},
+				Created:                   tsclient.Time{time.Date(2022, 2, 10, 11, 50, 23, 0, time.UTC)},
+				Expires:                   tsclient.Time{time.Date(2022, 8, 9, 11, 50, 23, 0, time.UTC)},
 				Hostname:                  "test",
 				IsExternal:                false,
-				LastSeen:                  tailscale.Time{time.Date(2022, 3, 9, 20, 3, 42, 0, time.UTC)},
+				LastSeen:                  tsclient.Time{time.Date(2022, 3, 9, 20, 3, 42, 0, time.UTC)},
 				MachineKey:                "mkey:test",
 				NodeKey:                   "nodekey:test",
 				OS:                        "windows",
@@ -119,53 +119,53 @@ func TestDevices_Unmarshal(t *testing.T) {
 	tt := []struct {
 		Name           string
 		DevicesContent []byte
-		Expected       []tailscale.Device
+		Expected       []tsclient.Device
 		UnmarshalFunc  func(data []byte, v interface{}) error
 	}{
 		{
 			Name:           "It should handle badly formed devices",
 			DevicesContent: jsonDevices,
 			UnmarshalFunc:  json.Unmarshal,
-			Expected: []tailscale.Device{
+			Expected: []tsclient.Device{
 				{
 					Addresses:                 []string{"100.101.102.103", "fd7a:115c:a1e0:ab12:4843:cd96:6265:6667"},
 					Authorized:                true,
 					BlocksIncomingConnections: false,
 					ClientVersion:             "",
-					Created:                   tailscale.Time{},
-					Expires: tailscale.Time{
+					Created:                   tsclient.Time{},
+					Expires: tsclient.Time{
 						time.Date(1, 1, 1, 00, 00, 00, 0, time.UTC),
 					},
 					Hostname:          "hello",
 					ID:                "50052",
 					IsExternal:        true,
 					KeyExpiryDisabled: true,
-					LastSeen: tailscale.Time{
+					LastSeen: tsclient.Time{
 						time.Date(2022, 4, 15, 13, 24, 40, 0, time.UTC),
 					},
 					MachineKey:      "",
-					Name:            "hello.tailscale.com",
+					Name:            "hello.example.com",
 					NodeKey:         "nodekey:30dc3c061ac8b33fdc6d88a4a67b053b01b56930d78cae0cf7a164411d424c0d",
 					OS:              "linux",
 					UpdateAvailable: false,
-					User:            "services@tailscale.com",
+					User:            "services@example.com",
 				},
 				{
 					Addresses:                 []string{"100.121.200.21", "fd7a:115c:a1e0:ab12:4843:cd96:6265:e618"},
 					Authorized:                true,
 					BlocksIncomingConnections: false,
 					ClientVersion:             "1.22.2-t60b671955-gecc5d9846",
-					Created: tailscale.Time{
+					Created: tsclient.Time{
 						time.Date(2022, 3, 5, 17, 10, 27, 0, time.UTC),
 					},
-					Expires: tailscale.Time{
+					Expires: tsclient.Time{
 						time.Date(2022, 9, 1, 17, 10, 27, 0, time.UTC),
 					},
 					Hostname:          "foo",
 					ID:                "50053",
 					IsExternal:        false,
 					KeyExpiryDisabled: true,
-					LastSeen: tailscale.Time{
+					LastSeen: tsclient.Time{
 						time.Date(2022, 4, 15, 13, 25, 21, 0, time.UTC),
 					},
 					MachineKey:      "mkey:30dc3c061ac8b33fdc6d88a4a67b053b01b56930d78cae0cf7a164411d424c0d",
@@ -181,7 +181,7 @@ func TestDevices_Unmarshal(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.Name, func(t *testing.T) {
-			actual := make(map[string][]tailscale.Device)
+			actual := make(map[string][]tsclient.Device)
 
 			assert.NoError(t, tc.UnmarshalFunc(tc.DevicesContent, &actual))
 			assert.EqualValues(t, tc.Expected, actual["devices"])
@@ -207,7 +207,7 @@ func TestClient_DeviceSubnetRoutes(t *testing.T) {
 
 	client, server := NewTestHarness(t)
 	server.ResponseCode = http.StatusOK
-	server.ResponseBody = &tailscale.DeviceRoutes{
+	server.ResponseBody = &tsclient.DeviceRoutes{
 		Advertised: []string{"127.0.0.1"},
 		Enabled:    []string{"127.0.0.1"},
 	}
@@ -265,7 +265,7 @@ func TestClient_SetDeviceKey(t *testing.T) {
 	server.ResponseCode = http.StatusOK
 
 	const deviceID = "test"
-	expected := tailscale.DeviceKey{
+	expected := tsclient.DeviceKey{
 		KeyExpiryDisabled: true,
 	}
 
@@ -274,7 +274,7 @@ func TestClient_SetDeviceKey(t *testing.T) {
 	assert.EqualValues(t, http.MethodPost, server.Method)
 	assert.EqualValues(t, "/api/v2/device/"+deviceID+"/key", server.Path)
 
-	var actual tailscale.DeviceKey
+	var actual tsclient.DeviceKey
 	assert.NoError(t, json.Unmarshal(server.Body.Bytes(), &actual))
 	assert.EqualValues(t, expected, actual)
 
@@ -288,7 +288,7 @@ func TestClient_SetDeviceIPv4Address(t *testing.T) {
 	const deviceID = "test"
 	address := "100.64.0.1"
 
-	assert.NoError(t, client.Devices().SetDeviceIPv4Address(context.Background(), deviceID, address))
+	assert.NoError(t, client.Devices().SetIPv4Address(context.Background(), deviceID, address))
 	assert.Equal(t, http.MethodPost, server.Method)
 	assert.EqualValues(t, "/api/v2/device/"+deviceID+"/ip", server.Path)
 }
@@ -303,7 +303,7 @@ func TestClient_UserAgent(t *testing.T) {
 	assert.Equal(t, "tailscale-client-go", server.Header.Get("User-Agent"))
 
 	// Check a custom user-agent.
-	client = &tailscale.Client{
+	client = &tsclient.Client{
 		APIKey:    "fake key",
 		BaseURL:   server.BaseURL,
 		UserAgent: "custom-user-agent",

--- a/v2/tailscale_test.go
+++ b/v2/tailscale_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tsclient_test
 
 import (
 	"bytes"
@@ -11,8 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/tailscale/tailscale-client-go/v2"
+	tsclient "github.com/tailscale/tailscale-client-go/v2"
 )
 
 type TestServer struct {
@@ -29,7 +28,7 @@ type TestServer struct {
 	ResponseBody interface{}
 }
 
-func NewTestHarness(t *testing.T) (*tailscale.Client, *TestServer) {
+func NewTestHarness(t *testing.T) (*tsclient.Client, *TestServer) {
 	t.Helper()
 
 	testServer := &TestServer{
@@ -58,7 +57,7 @@ func NewTestHarness(t *testing.T) (*tailscale.Client, *TestServer) {
 	baseURL := fmt.Sprintf("http://localhost:%v", listener.Addr().(*net.TCPAddr).Port)
 	testServer.BaseURL, err = url.Parse(baseURL)
 	assert.NoError(t, err)
-	client := &tailscale.Client{
+	client := &tsclient.Client{
 		BaseURL: testServer.BaseURL,
 		APIKey:  "not a real key",
 		Tailnet: "example.com",

--- a/v2/testdata/devices.json
+++ b/v2/testdata/devices.json
@@ -16,11 +16,11 @@
       "keyExpiryDisabled": true,
       "lastSeen": "2022-04-15T13:24:40Z",
       "machineKey": "",
-      "name": "hello.tailscale.com",
+      "name": "hello.example.com",
       "nodeKey": "nodekey:30dc3c061ac8b33fdc6d88a4a67b053b01b56930d78cae0cf7a164411d424c0d",
       "os": "linux",
       "updateAvailable": false,
-      "user": "services@tailscale.com"
+      "user": "services@example.com"
     },
     {
       "addresses": [

--- a/v2/webhooks.go
+++ b/v2/webhooks.go
@@ -1,4 +1,4 @@
-package tailscale
+package tsclient
 
 import (
 	"context"

--- a/v2/webhooks_test.go
+++ b/v2/webhooks_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tsclient_test
 
 import (
 	"context"
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tailscale/tailscale-client-go/v2"
+	tsclient "github.com/tailscale/tailscale-client-go/v2"
 )
 
 func TestClient_CreateWebhook(t *testing.T) {
@@ -16,14 +16,14 @@ func TestClient_CreateWebhook(t *testing.T) {
 	client, server := NewTestHarness(t)
 	server.ResponseCode = http.StatusOK
 
-	req := tailscale.CreateWebhookRequest{
+	req := tsclient.CreateWebhookRequest{
 		EndpointURL:   "https://example.com/my/endpoint",
-		ProviderType:  tailscale.WebhookDiscordProviderType,
-		Subscriptions: []tailscale.WebhookSubscriptionType{tailscale.WebhookNodeCreated, tailscale.WebhookNodeApproved},
+		ProviderType:  tsclient.WebhookDiscordProviderType,
+		Subscriptions: []tsclient.WebhookSubscriptionType{tsclient.WebhookNodeCreated, tsclient.WebhookNodeApproved},
 	}
 
 	expectedSecret := "my-secret"
-	expectedWebhook := &tailscale.Webhook{
+	expectedWebhook := &tsclient.Webhook{
 		EndpointID:       "12345",
 		EndpointURL:      req.EndpointURL,
 		ProviderType:     req.ProviderType,
@@ -48,7 +48,7 @@ func TestClient_Webhooks(t *testing.T) {
 	client, server := NewTestHarness(t)
 	server.ResponseCode = http.StatusOK
 
-	expectedWebhooks := map[string][]tailscale.Webhook{
+	expectedWebhooks := map[string][]tsclient.Webhook{
 		"webhooks": {
 			{
 				EndpointID:       "12345",
@@ -57,7 +57,7 @@ func TestClient_Webhooks(t *testing.T) {
 				CreatorLoginName: "pretend@example.com",
 				Created:          time.Date(2022, 2, 10, 11, 50, 23, 0, time.UTC),
 				LastModified:     time.Date(2022, 2, 10, 11, 50, 23, 0, time.UTC),
-				Subscriptions:    []tailscale.WebhookSubscriptionType{tailscale.WebhookNodeCreated, tailscale.WebhookNodeApproved},
+				Subscriptions:    []tsclient.WebhookSubscriptionType{tsclient.WebhookNodeCreated, tsclient.WebhookNodeApproved},
 			},
 			{
 				EndpointID:       "54321",
@@ -66,7 +66,7 @@ func TestClient_Webhooks(t *testing.T) {
 				CreatorLoginName: "pretend2@example.com",
 				Created:          time.Date(2022, 2, 10, 11, 50, 23, 0, time.UTC),
 				LastModified:     time.Date(2022, 2, 10, 11, 50, 23, 0, time.UTC),
-				Subscriptions:    []tailscale.WebhookSubscriptionType{tailscale.WebhookNodeApproved},
+				Subscriptions:    []tsclient.WebhookSubscriptionType{tsclient.WebhookNodeApproved},
 			},
 		},
 	}
@@ -85,14 +85,14 @@ func TestClient_Webhook(t *testing.T) {
 	client, server := NewTestHarness(t)
 	server.ResponseCode = http.StatusOK
 
-	expectedWebhook := &tailscale.Webhook{
+	expectedWebhook := &tsclient.Webhook{
 		EndpointID:       "54321",
 		EndpointURL:      "https://example.com/my/endpoint/other",
 		ProviderType:     "slack",
 		CreatorLoginName: "pretend2@example.com",
 		Created:          time.Date(2022, 2, 10, 11, 50, 23, 0, time.UTC),
 		LastModified:     time.Date(2022, 2, 10, 11, 50, 23, 0, time.UTC),
-		Subscriptions:    []tailscale.WebhookSubscriptionType{tailscale.WebhookNodeApproved},
+		Subscriptions:    []tsclient.WebhookSubscriptionType{tsclient.WebhookNodeApproved},
 	}
 	server.ResponseBody = expectedWebhook
 
@@ -109,9 +109,9 @@ func TestClient_UpdateWebhook(t *testing.T) {
 	client, server := NewTestHarness(t)
 	server.ResponseCode = http.StatusOK
 
-	subscriptions := []tailscale.WebhookSubscriptionType{tailscale.WebhookNodeCreated, tailscale.WebhookNodeApproved, tailscale.WebhookNodeNeedsApproval}
+	subscriptions := []tsclient.WebhookSubscriptionType{tsclient.WebhookNodeCreated, tsclient.WebhookNodeApproved, tsclient.WebhookNodeNeedsApproval}
 
-	expectedWebhook := &tailscale.Webhook{
+	expectedWebhook := &tsclient.Webhook{
 		EndpointID:       "54321",
 		EndpointURL:      "https://example.com/my/endpoint/other",
 		ProviderType:     "slack",
@@ -160,14 +160,14 @@ func TestClient_RotateWebhookSecret(t *testing.T) {
 	server.ResponseCode = http.StatusOK
 
 	expectedSecret := "my-new-secret"
-	expectedWebhook := &tailscale.Webhook{
+	expectedWebhook := &tsclient.Webhook{
 		EndpointID:       "54321",
 		EndpointURL:      "https://example.com/my/endpoint/other",
 		ProviderType:     "slack",
 		CreatorLoginName: "pretend2@example.com",
 		Created:          time.Date(2022, 2, 10, 11, 50, 23, 0, time.UTC),
 		LastModified:     time.Date(2022, 2, 10, 11, 50, 23, 0, time.UTC),
-		Subscriptions:    []tailscale.WebhookSubscriptionType{tailscale.WebhookNodeApproved},
+		Subscriptions:    []tsclient.WebhookSubscriptionType{tsclient.WebhookNodeApproved},
 		Secret:           &expectedSecret,
 	}
 	server.ResponseBody = expectedWebhook


### PR DESCRIPTION
Some consumers of this SDK, for example terraform-provider-tailscale, use other packages named 'tailscale'. To avoid having to alias when importing this package, rename to 'tsclient' to avoid most collisions by default.

Updates tailscale/corp#21867