### PR TITLE
v2: correctly URL encode tailnet in buildTailnetURL

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -169,10 +169,8 @@ func (c *Client) buildURL(pathElements ...any) *url.URL {
 func (c *Client) buildTailnetURL(pathElements ...any) *url.URL {
 	allElements := make([]any, 2, len(pathElements)+2)
 	allElements[0] = "tailnet"
-	allElements[1] = url.PathEscape(c.Tailnet)
-	for _, element := range pathElements {
-		allElements = append(allElements, element)
-	}
+	allElements[1] = c.Tailnet
+	allElements = append(allElements, pathElements...)
 	return c.buildURL(allElements...)
 }
 

--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -1,21 +1,21 @@
-package tailscale_test
+package tailscale
 
 import (
 	_ "embed"
 	"io"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/tailscale/tailscale-client-go/v2"
+	"github.com/stretchr/testify/require"
 )
 
 func TestErrorData(t *testing.T) {
 	t.Parallel()
 
 	t.Run("It should return the data element from a valid error", func(t *testing.T) {
-		expected := tailscale.APIError{
-			Data: []tailscale.APIErrorData{
+		expected := APIError{
+			Data: []APIErrorData{
 				{
 					User: "user1@example.com",
 					Errors: []string{
@@ -25,11 +25,27 @@ func TestErrorData(t *testing.T) {
 			},
 		}
 
-		actual := tailscale.ErrorData(expected)
+		actual := ErrorData(expected)
 		assert.EqualValues(t, expected.Data, actual)
 	})
 
 	t.Run("It should return an empty slice for any other error", func(t *testing.T) {
-		assert.Empty(t, tailscale.ErrorData(io.EOF))
+		assert.Empty(t, ErrorData(io.EOF))
 	})
+}
+
+func Test_BuildTailnetURL(t *testing.T) {
+	t.Parallel()
+
+	base, err := url.Parse("http://example.com")
+	require.NoError(t, err)
+
+	c := &Client{
+		BaseURL: base,
+		Tailnet: "tn/with/slashes",
+	}
+	actual := c.buildTailnetURL("component/with/slashes")
+	expected, err := url.Parse("http://example.com/api/v2/tailnet/tn%2Fwith%2Fslashes/component%2Fwith%2Fslashes")
+	require.NoError(t, err)
+	assert.EqualValues(t, expected.String(), actual.String())
 }


### PR DESCRIPTION
Adds unit test to test URL building.

Updates tailscale/corp#21867