### PR TITLE
v2: add DevicePostureResource.GetIntegration

### DIFF
--- a/v2/device_posture.go
+++ b/v2/device_posture.go
@@ -97,3 +97,14 @@ func (pr *DevicePostureResource) DeleteIntegration(ctx context.Context, id strin
 
 	return pr.do(req, nil)
 }
+
+// GetIntegration gets the PostureIntegration identified by id.
+func (pr *DevicePostureResource) GetIntegration(ctx context.Context, id string) (*PostureIntegration, error) {
+	req, err := pr.buildRequest(ctx, http.MethodGet, pr.buildURL("posture", "integrations", id))
+	if err != nil {
+		return nil, err
+	}
+
+	var resp PostureIntegration
+	return &resp, pr.do(req, &resp)
+}

--- a/v2/device_posture_test.go
+++ b/v2/device_posture_test.go
@@ -92,6 +92,28 @@ func TestClient_DevicePosture_DeleteIntegration(t *testing.T) {
 	assert.Equal(t, "/api/v2/posture/integrations/1", server.Path)
 }
 
+func TestClient_DevicePosture_GetIntegration(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	resp := &tsclient.PostureIntegration{
+		ID:       "1",
+		Provider: tsclient.PostureIntegrationProviderIntune,
+		CloudID:  "cloudid1",
+		ClientID: "clientid1",
+		TenantID: "tenantid1",
+	}
+	server.ResponseBody = resp
+
+	actualResp, err := client.DevicePosture().GetIntegration(context.Background(), "1")
+	assert.NoError(t, err)
+	assert.Equal(t, http.MethodGet, server.Method)
+	assert.Equal(t, "/api/v2/posture/integrations/1", server.Path)
+	assert.Equal(t, resp, actualResp)
+}
+
 func TestClient_DevicePosture_ListIntegrations(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Allows getting a single device posture integration by id.

Updates tailscale/corp#21624