### PR TITLE
v2: return base SplitDNSResponse instead of pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 A client implementation for the [Tailscale](https://tailscale.com) HTTP API.
 For more details, please see [API documentation](https://github.com/tailscale/tailscale/blob/main/api.md).
 
-A [V2](v2) implementation of the client is under active development, use at your own risk.
+A [V2](v2) implementation of the client is under active development, use at your own risk and expect breaking changes.
 
 # Example
 

--- a/v2/client.go
+++ b/v2/client.go
@@ -1,7 +1,7 @@
 // Package tsclient contains a basic implementation of a client for the Tailscale HTTP api. Documentation is here:
 // https://tailscale.com/api
 //
-// WARNING - this v2 implementation is under active development, use at your own risk.
+// WARNING - this v2 implementation is under active development, use at your own risk and expect breaking changes.
 package tsclient
 
 import (

--- a/v2/dns.go
+++ b/v2/dns.go
@@ -10,11 +10,11 @@ type DNSResource struct {
 }
 
 type (
-	// SplitDnsRequest is a map from domain names to a list of nameservers.
-	SplitDnsRequest map[string][]string
+	// SplitDNSRequest is a map from domain names to a list of nameservers.
+	SplitDNSRequest map[string][]string
 
-	// SplitDnsResponse is a map from domain names to a list of nameservers.
-	SplitDnsResponse SplitDnsRequest
+	// SplitDNSResponse is a map from domain names to a list of nameservers.
+	SplitDNSResponse SplitDNSRequest
 
 	DNSPreferences struct {
 		MagicDNS bool `json:"magicDNS"`
@@ -77,29 +77,32 @@ func (dr *DNSResource) Nameservers(ctx context.Context) ([]string, error) {
 }
 
 // UpdateSplitDNS updates the split DNS settings for a tailnet using the
-// provided SplitDnsRequest object. This is a PATCH operation that performs
+// provided [SplitDNSRequest] object. This is a PATCH operation that performs
 // partial updates of the underlying data structure.
 //
 // Mapping a domain to a nil slice in the request will unset the nameservers
 // associated with that domain. Values provided for domains will overwrite the
 // current value associated with the domain. Domains not included in the request
 // will remain unchanged.
-func (dr *DNSResource) UpdateSplitDNS(ctx context.Context, request SplitDnsRequest) (*SplitDnsResponse, error) {
+func (dr *DNSResource) UpdateSplitDNS(ctx context.Context, request SplitDNSRequest) (SplitDNSResponse, error) {
 	req, err := dr.buildRequest(ctx, http.MethodPatch, dr.buildTailnetURL("dns", "split-dns"), requestBody(request))
 	if err != nil {
 		return nil, err
 	}
 
-	var resp SplitDnsResponse
-	return &resp, dr.do(req, &resp)
+	var resp SplitDNSResponse
+	if err := dr.do(req, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 // SetSplitDNS sets the split DNS settings for a tailnet using the provided
-// SplitDnsRequest object. This is a PUT operation that fully replaces the underlying
+// [SplitDNSRequest] object. This is a PUT operation that fully replaces the underlying
 // data structure.
 //
-// Passing in an empty SplitDnsRequest will unset all split DNS mappings for the tailnet.
-func (dr *DNSResource) SetSplitDNS(ctx context.Context, request SplitDnsRequest) error {
+// Passing in an empty [SplitDNSRequest] will unset all split DNS mappings for the tailnet.
+func (dr *DNSResource) SetSplitDNS(ctx context.Context, request SplitDNSRequest) error {
 	req, err := dr.buildRequest(ctx, http.MethodPut, dr.buildTailnetURL("dns", "split-dns"), requestBody(request))
 	if err != nil {
 		return err
@@ -109,14 +112,17 @@ func (dr *DNSResource) SetSplitDNS(ctx context.Context, request SplitDnsRequest)
 }
 
 // SplitDNS retrieves the split DNS configuration for a tailnet.
-func (dr *DNSResource) SplitDNS(ctx context.Context) (*SplitDnsResponse, error) {
+func (dr *DNSResource) SplitDNS(ctx context.Context) (SplitDNSResponse, error) {
 	req, err := dr.buildRequest(ctx, http.MethodGet, dr.buildTailnetURL("dns", "split-dns"))
 	if err != nil {
 		return nil, err
 	}
 
-	var resp SplitDnsResponse
-	return &resp, dr.do(req, &resp)
+	var resp SplitDNSResponse
+	if err := dr.do(req, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 // Preferences retrieves the DNS preferences that are currently set for the given tailnet. Supply the tailnet of

--- a/v2/dns_test.go
+++ b/v2/dns_test.go
@@ -69,7 +69,7 @@ func TestClient_SplitDNS(t *testing.T) {
 	client, server := NewTestHarness(t)
 	server.ResponseCode = http.StatusOK
 
-	expectedNameservers := &tsclient.SplitDnsResponse{
+	expectedNameservers := tsclient.SplitDNSResponse{
 		"example.com": {"1.1.1.1", "1.2.3.4"},
 	}
 
@@ -141,11 +141,11 @@ func TestClient_UpdateSplitDNS(t *testing.T) {
 	server.ResponseCode = http.StatusOK
 
 	nameservers := []string{"1.1.2.1", "3.3.3.4"}
-	request := tsclient.SplitDnsRequest{
+	request := tsclient.SplitDNSRequest{
 		"example.com": nameservers,
 	}
 
-	expectedNameservers := &tsclient.SplitDnsResponse{
+	expectedNameservers := tsclient.SplitDNSResponse{
 		"example.com": nameservers,
 	}
 	server.ResponseBody = expectedNameservers
@@ -155,7 +155,7 @@ func TestClient_UpdateSplitDNS(t *testing.T) {
 	assert.Equal(t, http.MethodPatch, server.Method)
 	assert.Equal(t, "/api/v2/tailnet/example.com/dns/split-dns", server.Path)
 
-	body := make(tsclient.SplitDnsResponse)
+	body := make(tsclient.SplitDNSResponse)
 	assert.NoError(t, json.Unmarshal(server.Body.Bytes(), &body))
 	assert.EqualValues(t, nameservers, body["example.com"])
 	assert.EqualValues(t, expectedNameservers, resp)
@@ -168,7 +168,7 @@ func TestClient_SetSplitDNS(t *testing.T) {
 	server.ResponseCode = http.StatusOK
 
 	nameservers := []string{"1.1.2.1", "3.3.3.4"}
-	request := tsclient.SplitDnsRequest{
+	request := tsclient.SplitDNSRequest{
 		"example.com": nameservers,
 	}
 
@@ -176,7 +176,7 @@ func TestClient_SetSplitDNS(t *testing.T) {
 	assert.Equal(t, http.MethodPut, server.Method)
 	assert.Equal(t, "/api/v2/tailnet/example.com/dns/split-dns", server.Path)
 
-	body := make(tsclient.SplitDnsResponse)
+	body := make(tsclient.SplitDNSResponse)
 	assert.NoError(t, json.Unmarshal(server.Body.Bytes(), &body))
 	assert.EqualValues(t, nameservers, body["example.com"])
 }


### PR DESCRIPTION
Since SplitDNSResponse is already a map, it's possible to return nil without using a pointer.

This also renames SplitDnsResponse -> SplitDNSResponse to keep with Go casing conventions.

Updates tailscale/corp#21867