### PR TITLE
tailscale: make implicit use of tailnet explicit with TailnetClient

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -24,10 +24,10 @@ func main() {
 	apiKey := os.Getenv("TAILSCALE_API_KEY")
 	tailnet := os.Getenv("TAILSCALE_TAILNET")
 
-	&tsclient.Client{
+	c := &tsclient.Client{
 		APIKey:    apiKey,
-		Tailnet:   tailnet,
 	}
+	client := c.ForTailnet(tailnet)
 
 	devices, err := client.Devices().List(context.Background())
 }
@@ -51,11 +51,11 @@ func main() {
 	tailnet := os.Getenv("TAILSCALE_OAUTH_CLIENT_SECRET")
 	oauthScopes := []string{"all:write"}
 
-	&tsclient.Client{
+	c := &tsclient.Client{
 		APIKey:    apiKey,
-		Tailnet:   tailnet,
 	}
-	clientV2.UseOAuth(oauthClientID, oauthClientSecret, oauthScopes)
+	c.UseOAuth(oauthClientID, oauthClientSecret, oauthScopes)
+	client := c.ForTailnet(tailnet)
 
 	devices, err := client.Devices().List(context.Background())
 }

--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -42,9 +42,8 @@ func Test_BuildTailnetURL(t *testing.T) {
 
 	c := &Client{
 		BaseURL: base,
-		Tailnet: "tn/with/slashes",
 	}
-	actual := c.buildTailnetURL("component/with/slashes")
+	actual := c.ForTailnet("tn/with/slashes").buildTailnetURL("component/with/slashes")
 	expected, err := url.Parse("http://example.com/api/v2/tailnet/tn%2Fwith%2Fslashes/component%2Fwith%2Fslashes")
 	require.NoError(t, err)
 	assert.EqualValues(t, expected.String(), actual.String())

--- a/v2/contacts.go
+++ b/v2/contacts.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 )
 
-// ContactsResource provides access to https://tailscale.com/api#tag/contacts.
-type ContactsResource struct {
-	*Client
+// TailnetContactsResource provides access to https://tailscale.com/api#tag/contacts.
+type TailnetContactsResource struct {
+	*TailnetClient
 }
 
 const (
@@ -43,7 +43,7 @@ type (
 )
 
 // Get retieves the [Contacts] for the tailnet.
-func (cr *ContactsResource) Get(ctx context.Context) (*Contacts, error) {
+func (cr *TailnetContactsResource) Get(ctx context.Context) (*Contacts, error) {
 	req, err := cr.buildRequest(ctx, http.MethodGet, cr.buildTailnetURL("contacts"))
 	if err != nil {
 		return nil, err
@@ -55,7 +55,7 @@ func (cr *ContactsResource) Get(ctx context.Context) (*Contacts, error) {
 
 // Update updates the email for the specified [ContactType] within the tailnet.
 // If the email address changes, the system will send a verification email to confirm the change.
-func (cr *ContactsResource) Update(ctx context.Context, contactType ContactType, contact UpdateContactRequest) error {
+func (cr *TailnetContactsResource) Update(ctx context.Context, contactType ContactType, contact UpdateContactRequest) error {
 	req, err := cr.buildRequest(ctx, http.MethodPatch, cr.buildTailnetURL("contacts", contactType), requestBody(contact))
 	if err != nil {
 		return err

--- a/v2/device_posture.go
+++ b/v2/device_posture.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 )
 
-// DevicePostureResource provides access to https://tailscale.com/api#tag/deviceposture.
-type DevicePostureResource struct {
-	*Client
+// TailnetDevicePostureResource provides access to https://tailscale.com/api#tag/deviceposture.
+type TailnetDevicePostureResource struct {
+	*TailnetClient
 }
 
 const (
@@ -52,7 +52,7 @@ type (
 )
 
 // List lists every configured [PostureIntegration].
-func (pr *DevicePostureResource) ListIntegrations(ctx context.Context) ([]PostureIntegration, error) {
+func (pr *TailnetDevicePostureResource) ListIntegrations(ctx context.Context) ([]PostureIntegration, error) {
 	req, err := pr.buildRequest(ctx, http.MethodGet, pr.buildTailnetURL("posture", "integrations"))
 	if err != nil {
 		return nil, err
@@ -68,7 +68,7 @@ func (pr *DevicePostureResource) ListIntegrations(ctx context.Context) ([]Postur
 }
 
 // CreateIntegration creates a new posture integration, returning the resulting [PostureIntegration].
-func (pr *DevicePostureResource) CreateIntegration(ctx context.Context, intg CreatePostureIntegrationRequest) (*PostureIntegration, error) {
+func (pr *TailnetDevicePostureResource) CreateIntegration(ctx context.Context, intg CreatePostureIntegrationRequest) (*PostureIntegration, error) {
 	req, err := pr.buildRequest(ctx, http.MethodPost, pr.buildTailnetURL("posture", "integrations"), requestBody(intg))
 	if err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func (pr *DevicePostureResource) CreateIntegration(ctx context.Context, intg Cre
 }
 
 // UpdateIntegration updates the existing posture integration identified by id, returning the resulting [PostureIntegration].
-func (pr *DevicePostureResource) UpdateIntegration(ctx context.Context, id string, intg UpdatePostureIntegrationRequest) (*PostureIntegration, error) {
+func (pr *TailnetDevicePostureResource) UpdateIntegration(ctx context.Context, id string, intg UpdatePostureIntegrationRequest) (*PostureIntegration, error) {
 	req, err := pr.buildRequest(ctx, http.MethodPatch, pr.buildURL("posture", "integrations", id), requestBody(intg))
 	if err != nil {
 		return nil, err
@@ -90,7 +90,7 @@ func (pr *DevicePostureResource) UpdateIntegration(ctx context.Context, id strin
 }
 
 // DeleteIntegration deletes the posture integration identified by id.
-func (pr *DevicePostureResource) DeleteIntegration(ctx context.Context, id string) error {
+func (pr *TailnetDevicePostureResource) DeleteIntegration(ctx context.Context, id string) error {
 	req, err := pr.buildRequest(ctx, http.MethodDelete, pr.buildURL("posture", "integrations", id))
 	if err != nil {
 		return err
@@ -100,7 +100,7 @@ func (pr *DevicePostureResource) DeleteIntegration(ctx context.Context, id strin
 }
 
 // GetIntegration gets the posture integration identified by id.
-func (pr *DevicePostureResource) GetIntegration(ctx context.Context, id string) (*PostureIntegration, error) {
+func (pr *TailnetDevicePostureResource) GetIntegration(ctx context.Context, id string) (*PostureIntegration, error) {
 	req, err := pr.buildRequest(ctx, http.MethodGet, pr.buildURL("posture", "integrations", id))
 	if err != nil {
 		return nil, err

--- a/v2/devices.go
+++ b/v2/devices.go
@@ -7,9 +7,9 @@ import (
 	"time"
 )
 
-// DevicesResource provides access to https://tailscale.com/api#tag/devices.
-type DevicesResource struct {
-	*Client
+// TailnetDevicesResource provides access to https://tailscale.com/api#tag/devices.
+type TailnetDevicesResource struct {
+	*TailnetClient
 }
 
 type (
@@ -65,7 +65,7 @@ type Device struct {
 }
 
 // Get gets the [Device] identified by deviceID.
-func (dr *DevicesResource) Get(ctx context.Context, deviceID string) (*Device, error) {
+func (dr *TailnetDevicesResource) Get(ctx context.Context, deviceID string) (*Device, error) {
 	req, err := dr.buildRequest(ctx, http.MethodGet, dr.buildURL("device", deviceID))
 	if err != nil {
 		return nil, err
@@ -76,7 +76,7 @@ func (dr *DevicesResource) Get(ctx context.Context, deviceID string) (*Device, e
 }
 
 // List lists every [Device] in the tailnet.
-func (dr *DevicesResource) List(ctx context.Context) ([]Device, error) {
+func (dr *TailnetDevicesResource) List(ctx context.Context) ([]Device, error) {
 	req, err := dr.buildRequest(ctx, http.MethodGet, dr.buildTailnetURL("devices"))
 	if err != nil {
 		return nil, err
@@ -92,7 +92,7 @@ func (dr *DevicesResource) List(ctx context.Context) ([]Device, error) {
 }
 
 // SetAuthorized marks the specified device as authorized or not.
-func (dr *DevicesResource) SetAuthorized(ctx context.Context, deviceID string, authorized bool) error {
+func (dr *TailnetDevicesResource) SetAuthorized(ctx context.Context, deviceID string, authorized bool) error {
 	req, err := dr.buildRequest(ctx, http.MethodPost, dr.buildURL("device", deviceID, "authorized"), requestBody(map[string]bool{
 		"authorized": authorized,
 	}))
@@ -104,7 +104,7 @@ func (dr *DevicesResource) SetAuthorized(ctx context.Context, deviceID string, a
 }
 
 // Delete deletes the device identified by deviceID.
-func (dr *DevicesResource) Delete(ctx context.Context, deviceID string) error {
+func (dr *TailnetDevicesResource) Delete(ctx context.Context, deviceID string) error {
 	req, err := dr.buildRequest(ctx, http.MethodDelete, dr.buildURL("device", deviceID))
 	if err != nil {
 		return err
@@ -114,7 +114,7 @@ func (dr *DevicesResource) Delete(ctx context.Context, deviceID string) error {
 }
 
 // SetTags updates the tags of the device identified by deviceID.
-func (dr *DevicesResource) SetTags(ctx context.Context, deviceID string, tags []string) error {
+func (dr *TailnetDevicesResource) SetTags(ctx context.Context, deviceID string, tags []string) error {
 	req, err := dr.buildRequest(ctx, http.MethodPost, dr.buildURL("device", deviceID, "tags"), requestBody(map[string][]string{
 		"tags": tags,
 	}))
@@ -134,7 +134,7 @@ type (
 )
 
 // SetKey updates the properties of a device's key.
-func (dr *DevicesResource) SetKey(ctx context.Context, deviceID string, key DeviceKey) error {
+func (dr *TailnetDevicesResource) SetKey(ctx context.Context, deviceID string, key DeviceKey) error {
 	req, err := dr.buildRequest(ctx, http.MethodPost, dr.buildURL("device", deviceID, "key"), requestBody(key))
 	if err != nil {
 		return err
@@ -144,7 +144,7 @@ func (dr *DevicesResource) SetKey(ctx context.Context, deviceID string, key Devi
 }
 
 // SetDeviceIPv4Address sets the Tailscale IPv4 address of the device.
-func (dr *DevicesResource) SetIPv4Address(ctx context.Context, deviceID string, ipv4Address string) error {
+func (dr *TailnetDevicesResource) SetIPv4Address(ctx context.Context, deviceID string, ipv4Address string) error {
 	req, err := dr.buildRequest(ctx, http.MethodPost, dr.buildURL("device", deviceID, "ip"), requestBody(map[string]string{
 		"ipv4": ipv4Address,
 	}))
@@ -157,7 +157,7 @@ func (dr *DevicesResource) SetIPv4Address(ctx context.Context, deviceID string, 
 
 // SetSubnetRoutes sets which subnet routes are enabled to be routed by a device by replacing the existing list
 // of subnet routes with the supplied routes. Routes can be enabled without a device advertising them (e.g. for preauth).
-func (dr *DevicesResource) SetSubnetRoutes(ctx context.Context, deviceID string, routes []string) error {
+func (dr *TailnetDevicesResource) SetSubnetRoutes(ctx context.Context, deviceID string, routes []string) error {
 	req, err := dr.buildRequest(ctx, http.MethodPost, dr.buildURL("device", deviceID, "routes"), requestBody(map[string][]string{
 		"routes": routes,
 	}))
@@ -171,7 +171,7 @@ func (dr *DevicesResource) SetSubnetRoutes(ctx context.Context, deviceID string,
 // SubnetRoutes Retrieves the list of subnet routes that a device is advertising, as well as those that are
 // enabled for it. Enabled routes are not necessarily advertised (e.g. for pre-enabling), and likewise, advertised
 // routes are not necessarily enabled.
-func (dr *DevicesResource) SubnetRoutes(ctx context.Context, deviceID string) (*DeviceRoutes, error) {
+func (dr *TailnetDevicesResource) SubnetRoutes(ctx context.Context, deviceID string) (*DeviceRoutes, error) {
 	req, err := dr.buildRequest(ctx, http.MethodGet, dr.buildURL("device", deviceID, "routes"))
 	if err != nil {
 		return nil, err

--- a/v2/devices_test.go
+++ b/v2/devices_test.go
@@ -303,11 +303,11 @@ func TestClient_UserAgent(t *testing.T) {
 	assert.Equal(t, "tailscale-client-go", server.Header.Get("User-Agent"))
 
 	// Check a custom user-agent.
-	client = &tsclient.Client{
+	client = (&tsclient.Client{
 		APIKey:    "fake key",
 		BaseURL:   server.BaseURL,
 		UserAgent: "custom-user-agent",
-	}
+	}).ForTailnet("example.com")
 	assert.NoError(t, client.Devices().SetAuthorized(context.Background(), "test", true))
 	assert.Equal(t, "custom-user-agent", server.Header.Get("User-Agent"))
 }

--- a/v2/dns.go
+++ b/v2/dns.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 )
 
-// DNSResource provides access to https://tailscale.com/api#tag/dns.
-type DNSResource struct {
-	*Client
+// TailnetDNSResource provides access to https://tailscale.com/api#tag/dns.
+type TailnetDNSResource struct {
+	*TailnetClient
 }
 
 type (
@@ -23,7 +23,7 @@ type (
 )
 
 // SetSearchPaths replaces the list of search paths with the list supplied by the user and returns an error otherwise.
-func (dr *DNSResource) SetSearchPaths(ctx context.Context, searchPaths []string) error {
+func (dr *TailnetDNSResource) SetSearchPaths(ctx context.Context, searchPaths []string) error {
 	req, err := dr.buildRequest(ctx, http.MethodPost, dr.buildTailnetURL("dns", "searchpaths"), requestBody(map[string][]string{
 		"searchPaths": searchPaths,
 	}))
@@ -35,7 +35,7 @@ func (dr *DNSResource) SetSearchPaths(ctx context.Context, searchPaths []string)
 }
 
 // SearchPaths retrieves the list of search paths that is currently set for the given tailnet.
-func (dr *DNSResource) SearchPaths(ctx context.Context) ([]string, error) {
+func (dr *TailnetDNSResource) SearchPaths(ctx context.Context) ([]string, error) {
 	req, err := dr.buildRequest(ctx, http.MethodGet, dr.buildTailnetURL("dns", "searchpaths"))
 	if err != nil {
 		return nil, err
@@ -51,7 +51,7 @@ func (dr *DNSResource) SearchPaths(ctx context.Context) ([]string, error) {
 
 // SetNameservers replaces the list of DNS nameservers for the given tailnet with the list supplied by the user. Note
 // that changing the list of DNS nameservers may also affect the status of MagicDNS (if MagicDNS is on).
-func (dr *DNSResource) SetNameservers(ctx context.Context, dns []string) error {
+func (dr *TailnetDNSResource) SetNameservers(ctx context.Context, dns []string) error {
 	req, err := dr.buildRequest(ctx, http.MethodPost, dr.buildTailnetURL("dns", "nameservers"), requestBody(map[string][]string{
 		"dns": dns,
 	}))
@@ -63,7 +63,7 @@ func (dr *DNSResource) SetNameservers(ctx context.Context, dns []string) error {
 }
 
 // Nameservers lists the DNS nameservers for the tailnet
-func (dr *DNSResource) Nameservers(ctx context.Context) ([]string, error) {
+func (dr *TailnetDNSResource) Nameservers(ctx context.Context) ([]string, error) {
 	req, err := dr.buildRequest(ctx, http.MethodGet, dr.buildTailnetURL("dns", "nameservers"))
 	if err != nil {
 		return nil, err
@@ -85,7 +85,7 @@ func (dr *DNSResource) Nameservers(ctx context.Context) ([]string, error) {
 // associated with that domain. Values provided for domains will overwrite the
 // current value associated with the domain. Domains not included in the request
 // will remain unchanged.
-func (dr *DNSResource) UpdateSplitDNS(ctx context.Context, request SplitDNSRequest) (SplitDNSResponse, error) {
+func (dr *TailnetDNSResource) UpdateSplitDNS(ctx context.Context, request SplitDNSRequest) (SplitDNSResponse, error) {
 	req, err := dr.buildRequest(ctx, http.MethodPatch, dr.buildTailnetURL("dns", "split-dns"), requestBody(request))
 	if err != nil {
 		return nil, err
@@ -103,7 +103,7 @@ func (dr *DNSResource) UpdateSplitDNS(ctx context.Context, request SplitDNSReque
 // data structure.
 //
 // Passing in an empty [SplitDNSRequest] will unset all split DNS mappings for the tailnet.
-func (dr *DNSResource) SetSplitDNS(ctx context.Context, request SplitDNSRequest) error {
+func (dr *TailnetDNSResource) SetSplitDNS(ctx context.Context, request SplitDNSRequest) error {
 	req, err := dr.buildRequest(ctx, http.MethodPut, dr.buildTailnetURL("dns", "split-dns"), requestBody(request))
 	if err != nil {
 		return err
@@ -113,7 +113,7 @@ func (dr *DNSResource) SetSplitDNS(ctx context.Context, request SplitDNSRequest)
 }
 
 // SplitDNS retrieves the split DNS configuration for the tailnet.
-func (dr *DNSResource) SplitDNS(ctx context.Context) (SplitDNSResponse, error) {
+func (dr *TailnetDNSResource) SplitDNS(ctx context.Context) (SplitDNSResponse, error) {
 	req, err := dr.buildRequest(ctx, http.MethodGet, dr.buildTailnetURL("dns", "split-dns"))
 	if err != nil {
 		return nil, err
@@ -127,7 +127,7 @@ func (dr *DNSResource) SplitDNS(ctx context.Context) (SplitDNSResponse, error) {
 }
 
 // Preferences retrieves the DNS preferences that are currently set for the given tailnet.
-func (dr *DNSResource) Preferences(ctx context.Context) (*DNSPreferences, error) {
+func (dr *TailnetDNSResource) Preferences(ctx context.Context) (*DNSPreferences, error) {
 	req, err := dr.buildRequest(ctx, http.MethodGet, dr.buildTailnetURL("dns", "preferences"))
 	if err != nil {
 		return nil, err
@@ -139,7 +139,7 @@ func (dr *DNSResource) Preferences(ctx context.Context) (*DNSPreferences, error)
 
 // SetPreferences replaces the DNS preferences for the tailnet, specifically, the MagicDNS setting. Note that MagicDNS
 // is dependent on DNS servers.
-func (dr *DNSResource) SetPreferences(ctx context.Context, preferences DNSPreferences) error {
+func (dr *TailnetDNSResource) SetPreferences(ctx context.Context, preferences DNSPreferences) error {
 	req, err := dr.buildRequest(ctx, http.MethodPost, dr.buildTailnetURL("dns", "preferences"), requestBody(preferences))
 	if err != nil {
 		return nil

--- a/v2/keys.go
+++ b/v2/keys.go
@@ -6,9 +6,9 @@ import (
 	"time"
 )
 
-// KeysResource provides access to https://tailscale.com/api#tag/keys.
-type KeysResource struct {
-	*Client
+// TailnetKeysResource provides access to https://tailscale.com/api#tag/keys.
+type TailnetKeysResource struct {
+	*TailnetClient
 }
 
 type (
@@ -45,7 +45,7 @@ type (
 )
 
 // Create creates a new authentication key. Returns the generated [Key] if successful.
-func (kr *KeysResource) Create(ctx context.Context, ckr CreateKeyRequest) (*Key, error) {
+func (kr *TailnetKeysResource) Create(ctx context.Context, ckr CreateKeyRequest) (*Key, error) {
 	req, err := kr.buildRequest(ctx, http.MethodPost, kr.buildTailnetURL("keys"), requestBody(ckr))
 	if err != nil {
 		return nil, err
@@ -57,7 +57,7 @@ func (kr *KeysResource) Create(ctx context.Context, ckr CreateKeyRequest) (*Key,
 
 // Get returns all information on a [Key] whose identifier matches the one provided. This will not return the
 // authentication key itself, just the metadata.
-func (kr *KeysResource) Get(ctx context.Context, id string) (*Key, error) {
+func (kr *TailnetKeysResource) Get(ctx context.Context, id string) (*Key, error) {
 	req, err := kr.buildRequest(ctx, http.MethodGet, kr.buildTailnetURL("keys", id))
 	if err != nil {
 		return nil, err
@@ -69,7 +69,7 @@ func (kr *KeysResource) Get(ctx context.Context, id string) (*Key, error) {
 
 // List returns every [Key] within the tailnet. The only fields set for each [Key] will be its identifier.
 // The keys returned are relative to the user that owns the API key used to authenticate the client.
-func (kr *KeysResource) List(ctx context.Context) ([]Key, error) {
+func (kr *TailnetKeysResource) List(ctx context.Context) ([]Key, error) {
 	req, err := kr.buildRequest(ctx, http.MethodGet, kr.buildTailnetURL("keys"))
 	if err != nil {
 		return nil, err
@@ -84,7 +84,7 @@ func (kr *KeysResource) List(ctx context.Context) ([]Key, error) {
 }
 
 // Delete removes an authentication key from the tailnet.
-func (kr *KeysResource) Delete(ctx context.Context, id string) error {
+func (kr *TailnetKeysResource) Delete(ctx context.Context, id string) error {
 	req, err := kr.buildRequest(ctx, http.MethodDelete, kr.buildTailnetURL("keys", id))
 	if err != nil {
 		return err

--- a/v2/logging.go
+++ b/v2/logging.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 )
 
-// LoggingResource provides access to https://tailscale.com/api#tag/logging.
-type LoggingResource struct {
-	*Client
+// TailnetLoggingResource provides access to https://tailscale.com/api#tag/logging.
+type TailnetLoggingResource struct {
+	*TailnetClient
 }
 
 const (
@@ -49,7 +49,7 @@ type (
 )
 
 // LogstreamConfiguration retrieves the tailnet's [LogstreamConfiguration] for the given [LogType].
-func (lr *LoggingResource) LogstreamConfiguration(ctx context.Context, logType LogType) (*LogstreamConfiguration, error) {
+func (lr *TailnetLoggingResource) LogstreamConfiguration(ctx context.Context, logType LogType) (*LogstreamConfiguration, error) {
 	req, err := lr.buildRequest(ctx, http.MethodGet, lr.buildTailnetURL("logging", logType, "stream"))
 	if err != nil {
 		return nil, err
@@ -60,7 +60,7 @@ func (lr *LoggingResource) LogstreamConfiguration(ctx context.Context, logType L
 }
 
 // SetLogstreamConfiguration sets the tailnet's [LogstreamConfiguration] for the given [LogType].
-func (lr *LoggingResource) SetLogstreamConfiguration(ctx context.Context, logType LogType, request SetLogstreamConfigurationRequest) error {
+func (lr *TailnetLoggingResource) SetLogstreamConfiguration(ctx context.Context, logType LogType, request SetLogstreamConfigurationRequest) error {
 	req, err := lr.buildRequest(ctx, http.MethodPut, lr.buildTailnetURL("logging", logType, "stream"), requestBody(request))
 	if err != nil {
 		return err
@@ -70,7 +70,7 @@ func (lr *LoggingResource) SetLogstreamConfiguration(ctx context.Context, logTyp
 }
 
 // DeleteLogstreamConfiguration deletes the tailnet's [LogstreamConfiguration] for the given [LogType].
-func (lr *LoggingResource) DeleteLogstreamConfiguration(ctx context.Context, logType LogType) error {
+func (lr *TailnetLoggingResource) DeleteLogstreamConfiguration(ctx context.Context, logType LogType) error {
 	req, err := lr.buildRequest(ctx, http.MethodDelete, lr.buildTailnetURL("logging", logType, "stream"))
 	if err != nil {
 		return err

--- a/v2/policyfile.go
+++ b/v2/policyfile.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 )
 
-// PolicyFileResource provides access to https://tailscale.com/api#tag/policyfile.
-type PolicyFileResource struct {
-	*Client
+// TailnetPolicyFileResource provides access to https://tailscale.com/api#tag/policyfile.
+type TailnetPolicyFileResource struct {
+	*TailnetClient
 }
 
 type (
@@ -109,7 +109,7 @@ type (
 )
 
 // Get retrieves the [ACL] that is currently set for the tailnet.
-func (pr *PolicyFileResource) Get(ctx context.Context) (*ACL, error) {
+func (pr *TailnetPolicyFileResource) Get(ctx context.Context) (*ACL, error) {
 	req, err := pr.buildRequest(ctx, http.MethodGet, pr.buildTailnetURL("acl"))
 	if err != nil {
 		return nil, err
@@ -120,7 +120,7 @@ func (pr *PolicyFileResource) Get(ctx context.Context) (*ACL, error) {
 }
 
 // Raw retrieves the [ACL] that is currently set for the tailnet as a HuJSON string.
-func (pr *PolicyFileResource) Raw(ctx context.Context) (string, error) {
+func (pr *TailnetPolicyFileResource) Raw(ctx context.Context) (string, error) {
 	req, err := pr.buildRequest(ctx, http.MethodGet, pr.buildTailnetURL("acl"), requestContentType("application/hujson"))
 	if err != nil {
 		return "", err
@@ -136,7 +136,7 @@ func (pr *PolicyFileResource) Raw(ctx context.Context) (string, error) {
 
 // Set sets the [ACL] for the tailnet. acl can either be an [ACL], or a HuJSON string.
 // etag is an optional value that, if supplied, will be used in the "If-Match" HTTP request header.
-func (pr *PolicyFileResource) Set(ctx context.Context, acl any, etag string) error {
+func (pr *TailnetPolicyFileResource) Set(ctx context.Context, acl any, etag string) error {
 	headers := make(map[string]string)
 	if etag != "" {
 		headers["If-Match"] = fmt.Sprintf("%q", etag)
@@ -163,7 +163,7 @@ func (pr *PolicyFileResource) Set(ctx context.Context, acl any, etag string) err
 }
 
 // Validate validates the provided ACL via the API. acl can either be an [ACL], or a HuJSON string.
-func (pr *PolicyFileResource) Validate(ctx context.Context, acl any) error {
+func (pr *TailnetPolicyFileResource) Validate(ctx context.Context, acl any) error {
 	reqOpts := []requestOption{
 		requestBody(acl),
 	}

--- a/v2/tailnet_settings.go
+++ b/v2/tailnet_settings.go
@@ -7,7 +7,7 @@ import (
 
 // TailnetSettingsResource provides access to https://tailscale.com/api#tag/tailnetsettings.
 type TailnetSettingsResource struct {
-	*Client
+	*TailnetClient
 }
 
 type (

--- a/v2/tailscale_test.go
+++ b/v2/tailscale_test.go
@@ -29,7 +29,7 @@ type TestServer struct {
 	ResponseBody interface{}
 }
 
-func NewTestHarness(t *testing.T) (*tsclient.Client, *TestServer) {
+func NewTestHarness(t *testing.T) (*tsclient.TailnetClient, *TestServer) {
 	t.Helper()
 
 	testServer := &TestServer{
@@ -61,10 +61,9 @@ func NewTestHarness(t *testing.T) (*tsclient.Client, *TestServer) {
 	client := &tsclient.Client{
 		BaseURL: testServer.BaseURL,
 		APIKey:  "not a real key",
-		Tailnet: "example.com",
 	}
 
-	return client, testServer
+	return client.ForTailnet("example.com"), testServer
 }
 
 func (t *TestServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/v2/users.go
+++ b/v2/users.go
@@ -6,9 +6,9 @@ import (
 	"time"
 )
 
-// UsersResource provides access to https://tailscale.com/api#tag/users.
-type UsersResource struct {
-	*Client
+// TailnetUsersResource provides access to https://tailscale.com/api#tag/users.
+type TailnetUsersResource struct {
+	*TailnetClient
 }
 
 const (
@@ -63,7 +63,7 @@ type (
 
 // List lists every [User] of the tailnet. If userType and/or role are provided,
 // the list of users will be filtered by those.
-func (ur *UsersResource) List(ctx context.Context, userType *UserType, role *UserRole) ([]User, error) {
+func (ur *TailnetUsersResource) List(ctx context.Context, userType *UserType, role *UserRole) ([]User, error) {
 	u := ur.buildTailnetURL("users")
 	q := u.Query()
 	if userType != nil {
@@ -88,7 +88,7 @@ func (ur *UsersResource) List(ctx context.Context, userType *UserType, role *Use
 }
 
 // Get retrieves the [User] identified by the given id.
-func (ur *UsersResource) Get(ctx context.Context, id string) (*User, error) {
+func (ur *TailnetUsersResource) Get(ctx context.Context, id string) (*User, error) {
 	req, err := ur.buildRequest(ctx, http.MethodGet, ur.buildURL("users", id))
 	if err != nil {
 		return nil, err

--- a/v2/webhooks.go
+++ b/v2/webhooks.go
@@ -6,9 +6,9 @@ import (
 	"time"
 )
 
-// WebhooksResource provides access to https://tailscale.com/api#tag/webhooks.
-type WebhooksResource struct {
-	*Client
+// TailnetWebhooksResource provides access to https://tailscale.com/api#tag/webhooks.
+type TailnetWebhooksResource struct {
+	*TailnetClient
 }
 
 const (
@@ -68,7 +68,7 @@ type (
 
 // Create creates a new [Webhook] with the specifications provided in the [CreateWebhookRequest].
 // Returns the created [Webhook] if successful.
-func (wr *WebhooksResource) Create(ctx context.Context, request CreateWebhookRequest) (*Webhook, error) {
+func (wr *TailnetWebhooksResource) Create(ctx context.Context, request CreateWebhookRequest) (*Webhook, error) {
 	req, err := wr.buildRequest(ctx, http.MethodPost, wr.buildTailnetURL("webhooks"), requestBody(request))
 	if err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func (wr *WebhooksResource) Create(ctx context.Context, request CreateWebhookReq
 }
 
 // List lists every [Webhook] in the tailnet.
-func (wr *WebhooksResource) List(ctx context.Context) ([]Webhook, error) {
+func (wr *TailnetWebhooksResource) List(ctx context.Context) ([]Webhook, error) {
 	req, err := wr.buildRequest(ctx, http.MethodGet, wr.buildTailnetURL("webhooks"))
 	if err != nil {
 		return nil, err
@@ -94,7 +94,7 @@ func (wr *WebhooksResource) List(ctx context.Context) ([]Webhook, error) {
 }
 
 // Get retrieves a specific [Webhook].
-func (wr *WebhooksResource) Get(ctx context.Context, endpointID string) (*Webhook, error) {
+func (wr *TailnetWebhooksResource) Get(ctx context.Context, endpointID string) (*Webhook, error) {
 	req, err := wr.buildRequest(ctx, http.MethodGet, wr.buildURL("webhooks", endpointID))
 	if err != nil {
 		return nil, err
@@ -105,7 +105,7 @@ func (wr *WebhooksResource) Get(ctx context.Context, endpointID string) (*Webhoo
 }
 
 // Update updates an existing webhook's subscriptions. Returns the updated [Webhook] on success.
-func (wr *WebhooksResource) Update(ctx context.Context, endpointID string, subscriptions []WebhookSubscriptionType) (*Webhook, error) {
+func (wr *TailnetWebhooksResource) Update(ctx context.Context, endpointID string, subscriptions []WebhookSubscriptionType) (*Webhook, error) {
 	req, err := wr.buildRequest(ctx, http.MethodPatch, wr.buildURL("webhooks", endpointID), requestBody(map[string][]WebhookSubscriptionType{
 		"subscriptions": subscriptions,
 	}))
@@ -118,7 +118,7 @@ func (wr *WebhooksResource) Update(ctx context.Context, endpointID string, subsc
 }
 
 // Delete deletes a specific webhook.
-func (wr *WebhooksResource) Delete(ctx context.Context, endpointID string) error {
+func (wr *TailnetWebhooksResource) Delete(ctx context.Context, endpointID string) error {
 	req, err := wr.buildRequest(ctx, http.MethodDelete, wr.buildURL("webhooks", endpointID))
 	if err != nil {
 		return err
@@ -130,7 +130,7 @@ func (wr *WebhooksResource) Delete(ctx context.Context, endpointID string) error
 // Test queues a test event to be sent to a specific webhook.
 // Sending the test event is an asynchronous operation which will
 // typically happen a few seconds after using this method.
-func (wr *WebhooksResource) Test(ctx context.Context, endpointID string) error {
+func (wr *TailnetWebhooksResource) Test(ctx context.Context, endpointID string) error {
 	req, err := wr.buildRequest(ctx, http.MethodPost, wr.buildURL("webhooks", endpointID, "test"))
 	if err != nil {
 		return err
@@ -141,7 +141,7 @@ func (wr *WebhooksResource) Test(ctx context.Context, endpointID string) error {
 
 // RotateSecret rotates the secret associated with a webhook.
 // A new secret will be generated and set on the returned [Webhook].
-func (wr *WebhooksResource) RotateSecret(ctx context.Context, endpointID string) (*Webhook, error) {
+func (wr *TailnetWebhooksResource) RotateSecret(ctx context.Context, endpointID string) (*Webhook, error) {
 	req, err := wr.buildRequest(ctx, http.MethodPost, wr.buildURL("webhooks", endpointID, "rotate"))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In the future, it may be necessary to allow clients to work with multiple tailnets. TailnetClient gives us options for future refactoring without having to introduce a v3 API.

Updates tailscale/corp#21867