### PR TITLE
v2: return zero values on error

### DIFF
--- a/v2/contacts.go
+++ b/v2/contacts.go
@@ -49,8 +49,7 @@ func (cr *ContactsResource) Get(ctx context.Context) (*Contacts, error) {
 		return nil, err
 	}
 
-	var contacts Contacts
-	return &contacts, cr.do(req, &contacts)
+	return body[Contacts](cr, req)
 }
 
 // Update updates the email for the specified [ContactType] within the tailnet.

--- a/v2/device_posture.go
+++ b/v2/device_posture.go
@@ -74,8 +74,7 @@ func (pr *DevicePostureResource) CreateIntegration(ctx context.Context, intg Cre
 		return nil, err
 	}
 
-	var resp PostureIntegration
-	return &resp, pr.do(req, &resp)
+	return body[PostureIntegration](pr, req)
 }
 
 // UpdateIntegration updates the existing posture integration identified by id, returning the resulting [PostureIntegration].
@@ -85,8 +84,7 @@ func (pr *DevicePostureResource) UpdateIntegration(ctx context.Context, id strin
 		return nil, err
 	}
 
-	var resp PostureIntegration
-	return &resp, pr.do(req, &resp)
+	return body[PostureIntegration](pr, req)
 }
 
 // DeleteIntegration deletes the posture integration identified by id.
@@ -106,6 +104,5 @@ func (pr *DevicePostureResource) GetIntegration(ctx context.Context, id string) 
 		return nil, err
 	}
 
-	var resp PostureIntegration
-	return &resp, pr.do(req, &resp)
+	return body[PostureIntegration](pr, req)
 }

--- a/v2/devices.go
+++ b/v2/devices.go
@@ -71,8 +71,7 @@ func (dr *DevicesResource) Get(ctx context.Context, deviceID string) (*Device, e
 		return nil, err
 	}
 
-	var result Device
-	return &result, dr.do(req, &result)
+	return body[Device](dr, req)
 }
 
 // List lists every [Device] in the tailnet.
@@ -177,6 +176,5 @@ func (dr *DevicesResource) SubnetRoutes(ctx context.Context, deviceID string) (*
 		return nil, err
 	}
 
-	var result DeviceRoutes
-	return &result, dr.do(req, &result)
+	return body[DeviceRoutes](dr, req)
 }

--- a/v2/dns.go
+++ b/v2/dns.go
@@ -133,8 +133,7 @@ func (dr *DNSResource) Preferences(ctx context.Context) (*DNSPreferences, error)
 		return nil, err
 	}
 
-	var resp DNSPreferences
-	return &resp, dr.do(req, &resp)
+	return body[DNSPreferences](dr, req)
 }
 
 // SetPreferences replaces the DNS preferences for the tailnet, specifically, the MagicDNS setting. Note that MagicDNS

--- a/v2/keys.go
+++ b/v2/keys.go
@@ -51,8 +51,7 @@ func (kr *KeysResource) Create(ctx context.Context, ckr CreateKeyRequest) (*Key,
 		return nil, err
 	}
 
-	var key Key
-	return &key, kr.do(req, &key)
+	return body[Key](kr, req)
 }
 
 // Get returns all information on a [Key] whose identifier matches the one provided. This will not return the
@@ -63,8 +62,7 @@ func (kr *KeysResource) Get(ctx context.Context, id string) (*Key, error) {
 		return nil, err
 	}
 
-	var key Key
-	return &key, kr.do(req, &key)
+	return body[Key](kr, req)
 }
 
 // List returns every [Key] within the tailnet. The only fields set for each [Key] will be its identifier.

--- a/v2/logging.go
+++ b/v2/logging.go
@@ -55,8 +55,7 @@ func (lr *LoggingResource) LogstreamConfiguration(ctx context.Context, logType L
 		return nil, err
 	}
 
-	var logStream LogstreamConfiguration
-	return &logStream, lr.do(req, &logStream)
+	return body[LogstreamConfiguration](lr, req)
 }
 
 // SetLogstreamConfiguration sets the tailnet's [LogstreamConfiguration] for the given [LogType].

--- a/v2/policyfile.go
+++ b/v2/policyfile.go
@@ -115,8 +115,7 @@ func (pr *PolicyFileResource) Get(ctx context.Context) (*ACL, error) {
 		return nil, err
 	}
 
-	var resp ACL
-	return &resp, pr.do(req, &resp)
+	return body[ACL](pr, req)
 }
 
 // Raw retrieves the [ACL] that is currently set for the tailnet as a HuJSON string.

--- a/v2/tailnet_settings.go
+++ b/v2/tailnet_settings.go
@@ -60,8 +60,7 @@ func (tsr *TailnetSettingsResource) Get(ctx context.Context) (*TailnetSettings, 
 		return nil, err
 	}
 
-	var resp TailnetSettings
-	return &resp, tsr.do(req, &resp)
+	return body[TailnetSettings](tsr, req)
 }
 
 // Update updates the tailnet settings.

--- a/v2/users.go
+++ b/v2/users.go
@@ -94,6 +94,5 @@ func (ur *UsersResource) Get(ctx context.Context, id string) (*User, error) {
 		return nil, err
 	}
 
-	var resp User
-	return &resp, ur.do(req, &resp)
+	return body[User](ur, req)
 }

--- a/v2/webhooks.go
+++ b/v2/webhooks.go
@@ -74,8 +74,7 @@ func (wr *WebhooksResource) Create(ctx context.Context, request CreateWebhookReq
 		return nil, err
 	}
 
-	var webhook Webhook
-	return &webhook, wr.do(req, &webhook)
+	return body[Webhook](wr, req)
 }
 
 // List lists every [Webhook] in the tailnet.
@@ -100,8 +99,7 @@ func (wr *WebhooksResource) Get(ctx context.Context, endpointID string) (*Webhoo
 		return nil, err
 	}
 
-	var webhook Webhook
-	return &webhook, wr.do(req, &webhook)
+	return body[Webhook](wr, req)
 }
 
 // Update updates an existing webhook's subscriptions. Returns the updated [Webhook] on success.
@@ -113,8 +111,7 @@ func (wr *WebhooksResource) Update(ctx context.Context, endpointID string, subsc
 		return nil, err
 	}
 
-	var webhook Webhook
-	return &webhook, wr.do(req, &webhook)
+	return body[Webhook](wr, req)
 }
 
 // Delete deletes a specific webhook.
@@ -147,6 +144,5 @@ func (wr *WebhooksResource) RotateSecret(ctx context.Context, endpointID string)
 		return nil, err
 	}
 
-	var webhook Webhook
-	return &webhook, wr.do(req, &webhook)
+	return body[Webhook](wr, req)
 }


### PR DESCRIPTION
In Go, the default assumption is that if a func returns (T, error) and
its error is non-nil, the T value is invalid unless otherwise
documented. (io.Reader is the common example of a documented case
where both results can be valid)

On the flip side, the best practice for funcs returning (T, error) is
to only set one or the other non-nil, lest callers accidentally depend
on T always being non-nil and ossifying the implementation, making it
unable to be refactored later.

Updates #cleanup
