### PR TITLE
Fixup runtime error in client.go

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -115,6 +115,7 @@ func (c *Client) init() {
 // UseOAuth configures the client to use the specified OAuth credentials.
 // If [Client].HTTP was previously specified, this replaces it.
 func (c *Client) UseOAuth(clientID, clientSecret string, scopes []string) {
+	c.init()
 	oauthConfig := clientcredentials.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,


### PR DESCRIPTION
Without a `c.init()` in the `UseOAuth` method, `BaseURL` must be specified, or this code will result in a SIGSEGV on client.go:121 (122 after this commit).

This is _one possible_ way to fix this issue. Alternatively, implementing a `NewClient` would probably be reasonable too.