### PR TITLE
v2: unify OAuth configuration with rest of client initialization

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -24,12 +24,9 @@ import (
 )
 
 func main() {
-	apiKey := os.Getenv("TAILSCALE_API_KEY")
-	tailnet := os.Getenv("TAILSCALE_TAILNET")
-
 	&tsclient.Client{
-		APIKey:    apiKey,
-		Tailnet:   tailnet,
+		Tailnet: os.Getenv("TAILSCALE_TAILNET"),
+		APIKey:  os.Getenv("TAILSCALE_API_KEY"),
 	}
 
 	devices, err := client.Devices().List(context.Background())
@@ -50,16 +47,20 @@ import (
 )
 
 func main() {
-	oauthClientID := os.Getenv("TAILSCALE_OAUTH_CLIENT_ID")
-	tailnet := os.Getenv("TAILSCALE_OAUTH_CLIENT_SECRET")
+	oauthClientID := 
+	oauthClientID := 
 	oauthScopes := []string{"all:write"}
+	tailnet := os.Getenv("TAILSCALE_TAILNET")
 
 	&tsclient.Client{
-		APIKey:    apiKey,
-		Tailnet:   tailnet,
+		Tailnet: os.Getenv("TAILSCALE_TAILNET"),
+		HTTP:    tsclient.OAuthConfig{
+			ClientID:     os.Getenv("TAILSCALE_OAUTH_CLIENT_ID"),
+			ClientSecret: os.Getenv("TAILSCALE_OAUTH_CLIENT_SECRET"),
+			Scopes:       []string{"all:write"},
+		}.HTTPClient(),
 	}
-	clientV2.UseOAuth(oauthClientID, oauthClientSecret, oauthScopes)
-
+	
 	devices, err := client.Devices().List(context.Background())
 }
 ```

--- a/v2/oauth.go
+++ b/v2/oauth.go
@@ -1,0 +1,43 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
+package tsclient
+
+import (
+	"context"
+	"net/http"
+	"path"
+
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+// OAuthConfig provides a mechanism for configuring OAuth authentication.
+type OAuthConfig struct {
+	// ClientID is the client ID of the OAuth client.
+	ClientID string
+	// ClientSecret is the client secret of the OAuth client.
+	ClientSecret string
+	// Scopes are the scopes to request when generating tokens for this OAuth client.
+	Scopes []string
+	// BaseURL is an optional base URL for the API server to which we'll connect. Defaults to https://api.tailscale.com.
+	BaseURL string
+}
+
+// HTTPClient constructs an HTTP client that authenticates using OAuth.
+func (ocfg OAuthConfig) HTTPClient() *http.Client {
+	baseURL := ocfg.BaseURL
+	if baseURL == "" {
+		baseURL = defaultBaseURL.String()
+	}
+	oauthConfig := clientcredentials.Config{
+		ClientID:     ocfg.ClientID,
+		ClientSecret: ocfg.ClientSecret,
+		Scopes:       ocfg.Scopes,
+		TokenURL:     path.Join(baseURL, "/api/v2/oauth/token"),
+	}
+
+	// Use context.Background() here, since this is used to refresh the token in the future.
+	client := oauthConfig.Client(context.Background())
+	client.Timeout = defaultHttpClientTimeout
+	return client
+}


### PR DESCRIPTION
This avoids issues such as attempting to configure OAuth with an unitialized BaseURL.

Updates tailscale/corp#21867