### PR TITLE
v2: return ETag with ACL and raw ACL responses

### DIFF
--- a/v2/policyfile_test.go
+++ b/v2/policyfile_test.go
@@ -353,11 +353,13 @@ func TestClient_ACL(t *testing.T) {
 				Allow: []string{"100.60.3.4:22"},
 			},
 		},
+		ETag: "myetag",
 	}
+	server.ResponseHeader.Add("ETag", "myetag")
 
 	acl, err := client.PolicyFile().Get(context.Background())
 	assert.NoError(t, err)
-	assert.EqualValues(t, acl, server.ResponseBody)
+	assert.EqualValues(t, server.ResponseBody, acl)
 	assert.EqualValues(t, http.MethodGet, server.Method)
 	assert.EqualValues(t, "application/json", server.Header.Get("Accept"))
 	assert.EqualValues(t, "/api/v2/tailnet/example.com/acl", server.Path)
@@ -370,10 +372,15 @@ func TestClient_RawACL(t *testing.T) {
 
 	server.ResponseCode = http.StatusOK
 	server.ResponseBody = huJSONACL
+	server.ResponseHeader.Add("ETag", "myetag")
 
+	expectedRawACL := &tsclient.RawACL{
+		HuJSON: string(huJSONACL),
+		ETag:   "myetag",
+	}
 	acl, err := client.PolicyFile().Raw(context.Background())
 	assert.NoError(t, err)
-	assert.EqualValues(t, string(huJSONACL), acl)
+	assert.EqualValues(t, expectedRawACL, acl)
 	assert.EqualValues(t, http.MethodGet, server.Method)
 	assert.EqualValues(t, "application/hujson", server.Header.Get("Accept"))
 	assert.EqualValues(t, "/api/v2/tailnet/example.com/acl", server.Path)

--- a/v2/tailscale_test.go
+++ b/v2/tailscale_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"net/url"
@@ -28,15 +29,17 @@ type TestServer struct {
 	Body   *bytes.Buffer
 	Header http.Header
 
-	ResponseCode int
-	ResponseBody interface{}
+	ResponseCode   int
+	ResponseBody   interface{}
+	ResponseHeader http.Header
 }
 
 func NewTestHarness(t *testing.T) (*tsclient.Client, *TestServer) {
 	t.Helper()
 
 	testServer := &TestServer{
-		t: t,
+		t:              t,
+		ResponseHeader: make(http.Header),
 	}
 
 	mux := http.NewServeMux()
@@ -80,6 +83,7 @@ func (t *TestServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, err := io.Copy(t.Body, r.Body)
 	assert.NoError(t.t, err)
 
+	maps.Copy(w.Header(), t.ResponseHeader)
 	w.WriteHeader(t.ResponseCode)
 	if t.ResponseBody != nil {
 		switch body := t.ResponseBody.(type) {


### PR DESCRIPTION
This allows clients to know which ETag to provide when updating an ACL.

Updates #119