### PR TITLE
{tailscale,v2}: capitalize API, tweak package doc

### DIFF
--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -1,8 +1,9 @@
 // Copyright (c) David Bond, Tailscale Inc, & Contributors
 // SPDX-License-Identifier: MIT
 
-// Package tailscale contains a basic implementation of a client for the Tailscale HTTP api. Documentation is here:
-// https://github.com/tailscale/tailscale/blob/main/api.md
+// Package tailscale contains a basic implementation of a client for the Tailscale HTTP API.
+//
+// Documentation is at https://tailscale.com/api
 package tailscale
 
 import (

--- a/v2/client.go
+++ b/v2/client.go
@@ -1,8 +1,9 @@
 // Copyright (c) David Bond, Tailscale Inc, & Contributors
 // SPDX-License-Identifier: MIT
 
-// Package tsclient contains a basic implementation of a client for the Tailscale HTTP api. Documentation is here:
-// https://tailscale.com/api
+// Package tsclient contains a basic implementation of a client for the Tailscale HTTP API.
+//
+// Documentation is at https://tailscale.com/api
 package tsclient
 
 import (


### PR DESCRIPTION
Break the package doc up into a second paragraph so the "Docs are
here" part doesn't show up as the synopsis. And fix an old URL
in the v1 docs.
