### PR TITLE
Add tailnet lock fields to device structs

### DIFF
--- a/v2/devices.go
+++ b/v2/devices.go
@@ -62,6 +62,8 @@ type Device struct {
 	MachineKey                string   `json:"machineKey"`
 	NodeKey                   string   `json:"nodeKey"`
 	OS                        string   `json:"os"`
+	TailnetLockError          string   `json:"tailnetLockError"`
+	TailnetLockKey            string   `json:"tailnetLockKey"`
 	UpdateAvailable           bool     `json:"updateAvailable"`
 }
 

--- a/v2/devices_test.go
+++ b/v2/devices_test.go
@@ -61,6 +61,8 @@ func TestClient_Devices_Get(t *testing.T) {
 		MachineKey:                "mkey:test",
 		NodeKey:                   "nodekey:test",
 		OS:                        "windows",
+		TailnetLockError:          "test error",
+		TailnetLockKey:            "tlpub:test",
 		UpdateAvailable:           true,
 	}
 


### PR DESCRIPTION
The client doesn't return the values for `tailnetLockError` or `tailnetLockKey`, and these would be great to include, since they're included by default when listing devices anyway. 