### PR TITLE
Add SetName for Device

### DIFF
--- a/v2/devices.go
+++ b/v2/devices.go
@@ -67,6 +67,11 @@ type Device struct {
 	UpdateAvailable           bool     `json:"updateAvailable"`
 }
 
+type DevicePostureAttributes struct {
+	Attributes map[string]any  `json:"attributes"`
+	Expiries   map[string]Time `json:"expiries"`
+}
+
 // Get gets the [Device] identified by deviceID.
 func (dr *DevicesResource) Get(ctx context.Context, deviceID string) (*Device, error) {
 	req, err := dr.buildRequest(ctx, http.MethodGet, dr.buildURL("device", deviceID))
@@ -75,6 +80,15 @@ func (dr *DevicesResource) Get(ctx context.Context, deviceID string) (*Device, e
 	}
 
 	return body[Device](dr, req)
+}
+
+func (dr *DevicesResource) GetPostureAttributes(ctx context.Context, deviceID string) (*DevicePostureAttributes, error) {
+	req, err := dr.buildRequest(ctx, http.MethodGet, dr.buildURL("device", deviceID, "attributes"))
+	if err != nil {
+		return nil, err
+	}
+
+	return body[DevicePostureAttributes](dr, req)
 }
 
 // List lists every [Device] in the tailnet.

--- a/v2/devices.go
+++ b/v2/devices.go
@@ -72,6 +72,12 @@ type DevicePostureAttributes struct {
 	Expiries   map[string]Time `json:"expiries"`
 }
 
+type DevicePostureAttributeRequest struct {
+	Value   any    `json:"value"`
+	Expiry  Time   `json:"expiry"`
+	Comment string `json:"comment"`
+}
+
 // Get gets the [Device] identified by deviceID.
 func (dr *DevicesResource) Get(ctx context.Context, deviceID string) (*Device, error) {
 	req, err := dr.buildRequest(ctx, http.MethodGet, dr.buildURL("device", deviceID))
@@ -82,6 +88,7 @@ func (dr *DevicesResource) Get(ctx context.Context, deviceID string) (*Device, e
 	return body[Device](dr, req)
 }
 
+// GetPostureAttributes retrieves the posture attributes of the device identified by deviceID.
 func (dr *DevicesResource) GetPostureAttributes(ctx context.Context, deviceID string) (*DevicePostureAttributes, error) {
 	req, err := dr.buildRequest(ctx, http.MethodGet, dr.buildURL("device", deviceID, "attributes"))
 	if err != nil {
@@ -146,6 +153,16 @@ func (dr *DevicesResource) SetTags(ctx context.Context, deviceID string, tags []
 	req, err := dr.buildRequest(ctx, http.MethodPost, dr.buildURL("device", deviceID, "tags"), requestBody(map[string][]string{
 		"tags": tags,
 	}))
+	if err != nil {
+		return err
+	}
+
+	return dr.do(req, nil)
+}
+
+// SetPostureAttribute sets the posture attribute of the device identified by deviceID.
+func (dr *DevicesResource) SetPostureAttribute(ctx context.Context, deviceID, attributeKey string, request DevicePostureAttributeRequest) error {
+	req, err := dr.buildRequest(ctx, http.MethodPost, dr.buildURL("device", deviceID, "attributes", attributeKey), requestBody(request))
 	if err != nil {
 		return err
 	}

--- a/v2/devices.go
+++ b/v2/devices.go
@@ -115,6 +115,18 @@ func (dr *DevicesResource) Delete(ctx context.Context, deviceID string) error {
 	return dr.do(req, nil)
 }
 
+// SetName updates the name of the device by deviceID.
+func (dr *DevicesResource) SetName(ctx context.Context, deviceID, name string) error {
+	req, err := dr.buildRequest(ctx, http.MethodPost, dr.buildURL("device", deviceID, "name"), requestBody(map[string]string{
+		"name": name,
+	}))
+	if err != nil {
+		return err
+	}
+
+	return dr.do(req, nil)
+}
+
 // SetTags updates the tags of the device identified by deviceID.
 func (dr *DevicesResource) SetTags(ctx context.Context, deviceID string, tags []string) error {
 	req, err := dr.buildRequest(ctx, http.MethodPost, dr.buildURL("device", deviceID, "tags"), requestBody(map[string][]string{

--- a/v2/devices.go
+++ b/v2/devices.go
@@ -98,6 +98,16 @@ func (dr *DevicesResource) GetPostureAttributes(ctx context.Context, deviceID st
 	return body[DevicePostureAttributes](dr, req)
 }
 
+// SetPostureAttribute sets the posture attribute of the device identified by deviceID.
+func (dr *DevicesResource) SetPostureAttribute(ctx context.Context, deviceID, attributeKey string, request DevicePostureAttributeRequest) error {
+	req, err := dr.buildRequest(ctx, http.MethodPost, dr.buildURL("device", deviceID, "attributes", attributeKey), requestBody(request))
+	if err != nil {
+		return err
+	}
+
+	return dr.do(req, nil)
+}
+
 // List lists every [Device] in the tailnet.
 func (dr *DevicesResource) List(ctx context.Context) ([]Device, error) {
 	req, err := dr.buildRequest(ctx, http.MethodGet, dr.buildTailnetURL("devices"))
@@ -136,7 +146,7 @@ func (dr *DevicesResource) Delete(ctx context.Context, deviceID string) error {
 	return dr.do(req, nil)
 }
 
-// SetName updates the name of the device by deviceID.
+// SetName updates the name of the device identified by deviceID.
 func (dr *DevicesResource) SetName(ctx context.Context, deviceID, name string) error {
 	req, err := dr.buildRequest(ctx, http.MethodPost, dr.buildURL("device", deviceID, "name"), requestBody(map[string]string{
 		"name": name,
@@ -153,16 +163,6 @@ func (dr *DevicesResource) SetTags(ctx context.Context, deviceID string, tags []
 	req, err := dr.buildRequest(ctx, http.MethodPost, dr.buildURL("device", deviceID, "tags"), requestBody(map[string][]string{
 		"tags": tags,
 	}))
-	if err != nil {
-		return err
-	}
-
-	return dr.do(req, nil)
-}
-
-// SetPostureAttribute sets the posture attribute of the device identified by deviceID.
-func (dr *DevicesResource) SetPostureAttribute(ctx context.Context, deviceID, attributeKey string, request DevicePostureAttributeRequest) error {
-	req, err := dr.buildRequest(ctx, http.MethodPost, dr.buildURL("device", deviceID, "attributes", attributeKey), requestBody(request))
 	if err != nil {
 		return err
 	}

--- a/v2/devices_test.go
+++ b/v2/devices_test.go
@@ -245,6 +245,24 @@ func TestClient_SetDeviceAuthorized(t *testing.T) {
 	}
 }
 
+func TestClient_SetDeviceName(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	const deviceID = "test"
+	name := "test"
+
+	assert.NoError(t, client.Devices().SetName(context.Background(), deviceID, name))
+	assert.EqualValues(t, http.MethodPost, server.Method)
+	assert.EqualValues(t, "/api/v2/device/"+deviceID+"/name", server.Path)
+
+	body := make(map[string]string)
+	assert.NoError(t, json.Unmarshal(server.Body.Bytes(), &body))
+	assert.EqualValues(t, name, body["name"])
+}
+
 func TestClient_SetDeviceTags(t *testing.T) {
 	t.Parallel()
 

--- a/v2/devices_test.go
+++ b/v2/devices_test.go
@@ -310,6 +310,32 @@ func TestClient_SetDeviceTags(t *testing.T) {
 	assert.EqualValues(t, tags, body["tags"])
 }
 
+func TestClient_SetDevicePostureAttributes(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+	server.ResponseBody = nil
+
+	const deviceID = "test"
+	const attributeKey = "custom:test"
+
+	setRequest := tsclient.DevicePostureAttributeRequest{
+		Value:   "value",
+		Expiry:  tsclient.Time{time.Date(2022, 2, 10, 11, 50, 23, 0, time.UTC)},
+		Comment: "test",
+	}
+
+	assert.NoError(t, client.Devices().SetPostureAttribute(context.Background(), deviceID, attributeKey, setRequest))
+	assert.EqualValues(t, http.MethodPost, server.Method)
+	assert.EqualValues(t, "/api/v2/device/"+deviceID+"/attributes/"+attributeKey, server.Path)
+
+	var receivedRequest tsclient.DevicePostureAttributeRequest
+	err := json.Unmarshal(server.Body.Bytes(), &receivedRequest)
+	assert.NoError(t, err)
+	assert.EqualValues(t, setRequest, receivedRequest)
+}
+
 func TestClient_SetDeviceKey(t *testing.T) {
 	t.Parallel()
 
@@ -329,8 +355,8 @@ func TestClient_SetDeviceKey(t *testing.T) {
 	var actual tsclient.DeviceKey
 	assert.NoError(t, json.Unmarshal(server.Body.Bytes(), &actual))
 	assert.EqualValues(t, expected, actual)
-
 }
+
 func TestClient_SetDeviceIPv4Address(t *testing.T) {
 	t.Parallel()
 

--- a/v2/devices_test.go
+++ b/v2/devices_test.go
@@ -77,6 +77,35 @@ func TestClient_Devices_Get(t *testing.T) {
 	assert.EqualValues(t, expectedDevice, actualDevice)
 }
 
+func TestClient_Devices_GetPostureAttributes(t *testing.T) {
+	t.Parallel()
+
+	expectedAttributes := &tsclient.DevicePostureAttributes{
+		Attributes: map[string]interface{}{
+			"custom:key":          "value",
+			"node:os":             "linux",
+			"node:osVersion":      "5.19.0-42-generic",
+			"node:tsReleaseTrack": "stable",
+			"node:tsVersion":      "1.40.0",
+			"node:tsAutoUpdate":   false,
+		},
+		Expiries: map[string]tsclient.Time{
+			"custom:key": {time.Date(2022, 2, 10, 11, 50, 23, 0, time.UTC)},
+		},
+	}
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+	server.ResponseBody = expectedAttributes
+
+	actualAttributes, err := client.Devices().GetPostureAttributes(context.Background(), "testid")
+	assert.NoError(t, err)
+	assert.Equal(t, http.MethodGet, server.Method)
+	assert.Equal(t, "/api/v2/device/testid/attributes", server.Path)
+
+	assert.EqualValues(t, expectedAttributes, actualAttributes)
+}
+
 func TestClient_Devices_List(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This pull request adds the following features:

- Added a v2 client method to perform the [API call for setting a device name](https://tailscale.com/api#tag/devices/POST/device/{deviceId}/name).
- Added a v2 client method to perform the [API call for retrieving device posture attributes](https://tailscale.com/api#tag/devices/GET/device/{deviceId}/attributes).
- Added a v2 client method to perform the [API call for setting device posture attributes](https://tailscale.com/api#tag/devices/POST/device/{deviceId}/attributes/{attributeKey}).
